### PR TITLE
Add getter and setter for bitset in EnumSet

### DIFF
--- a/src/EnumSet.php
+++ b/src/EnumSet.php
@@ -205,4 +205,22 @@ class EnumSet implements Iterator, Countable
 
         return $cnt;
     }
+
+    /**
+     * Get the bitset
+     * @return int
+     */
+    public function getBitset() {
+        return $this->bitset;
+    }
+
+    /**
+     * Set the bitset, it resets the current position of the iterator
+     * @param int $bitset
+     * @return void
+     */
+    public function setBitset($bitset) {
+        $this->bitset=$bitset;
+        $this->rewind();
+    }
 }

--- a/src/EnumSet.php
+++ b/src/EnumSet.php
@@ -220,7 +220,7 @@ class EnumSet implements Iterator, Countable
      * @return void
      */
     public function setBitset($bitset) {
-        $this->bitset=$bitset;
+        $this->bitset = (int) $bitset;
         $this->rewind();
     }
 }

--- a/tests/MabeEnumTest/EnumSetTest.php
+++ b/tests/MabeEnumTest/EnumSetTest.php
@@ -250,4 +250,26 @@ class EnumSetTest extends TestCase
         $this->setExpectedException('OutOfRangeException');
         new EnumSet('MabeEnumTest\TestAsset\Enum65');
     }
+
+    public function testBitset(){
+        $enumSet = new EnumSet('MabeEnumTest\TestAsset\EnumBasic');
+
+        $enum1  = EnumBasic::ONE;
+        $enum2  = EnumBasic::TWO;
+
+        $this->assertNull($enumSet->attach($enum1));
+        $this->assertTrue($enumSet->getBitset()==(1<<EnumBasic::get($enum1)->getOrdinal()));
+
+        $this->assertNull($enumSet->attach($enum2));
+        $this->assertTrue($enumSet->getBitset()==(1<<EnumBasic::get($enum1)->getOrdinal() | 1<<EnumBasic::get($enum2)->getOrdinal()));
+
+
+        $this->assertNull($enumSet->detach($enum1));
+        $bitset=$enumSet->getBitset();
+        $enumSet2=new EnumSet('MabeEnumTest\TestAsset\EnumBasic');
+        $enumSet2->setBitset($bitset);
+
+        $this->assertFalse($enumSet2->contains($enum1));
+        $this->assertTrue($enumSet2->contains($enum2));
+    }
 }


### PR DESCRIPTION
Hello,

Often it's nessessary to save an EnumSet in a database or somewhere else.
My thougt was to only save only the bitset, serilize works also but need a hug amout of space, is not such easy searchable, and i don't think it works well if you upgrade your enum and load an old version from the database.(probably also not work with that solution)

What do you think about a getter and setter method for bitset?

ps. nice enum classes, thx for it.