### PR TITLE
Documentation: Clarify is() usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,11 @@ It's an abstract class that needs to be extended to use it.
     UserStatus::get(UserStatus::DELETED) != UserStatus::INACTIVE()
 
     // simplified way to compare two enumerators
-    UserStatus::ACTIVE()->is(UserStatus::ACTIVE);     // true
-    UserStatus::ACTIVE()->is(UserStatus::ACTIVE());   // true
-    UserStatus::ACTIVE()->is(UserStatus::DELETED);    // false
-    UserStatus::ACTIVE()->is(UserStatus::DELETED());  // false
+    $status = UserStatus::ACTIVE();
+    $status->is(UserStatus::ACTIVE);     // true
+    $status->is(UserStatus::ACTIVE());   // true
+    $status->is(UserStatus::DELETED);    // false
+    $status->is(UserStatus::DELETED());  // false
 ```
 
 ## Type-Hint


### PR DESCRIPTION
It's a subtle change, but showing some enum property assigned to a variable, and then using that variable as an object which has the `is()` method makes it a little clearer in my mind about how it could be used. i.e. no-one would bother to do `UserStatus::ACTIVE()->is(UserStatus::ACTIVE);` in real life code.