### PR TITLE
handle class constant visibility added in PHP-7.1

### DIFF
--- a/tests/MabeEnumTest/EnumTest.php
+++ b/tests/MabeEnumTest/EnumTest.php
@@ -6,6 +6,8 @@ use MabeEnumTest\TestAsset\EnumBasic;
 use MabeEnumTest\TestAsset\EnumInheritance;
 use MabeEnumTest\TestAsset\EnumAmbiguous;
 use MabeEnumTest\TestAsset\EnumExtendedAmbiguous;
+use MabeEnumTest\TestAsset\ConstVisibilityEnum;
+use MabeEnumTest\TestAsset\ConstVisibilityEnumExtended;
 use PHPUnit_Framework_TestCase as TestCase;
 use ReflectionClass;
 
@@ -254,5 +256,33 @@ class EnumTest extends TestCase
         $this->assertFalse($enum->has(EnumInheritance::ONE()));
         $this->assertTrue($enum->has(EnumBasic::ONE()));
         $this->assertTrue($enum->has(EnumBasic::ONE));
+    }
+    
+    public function testConstVisibility()
+    {
+        if (PHP_VERSION_ID < 70100) {
+            $this->markTestSkipped('This test is for PHP-7.1 and upper only');
+        }
+
+        $constants = ConstVisibilityEnum::getConstants();
+        $this->assertSame(array(
+            'IPUB' => ConstVisibilityEnum::IPUB,
+            'PUB'  => ConstVisibilityEnum::PUB,
+        ), $constants);
+    }
+    
+    public function testConstVisibilityExtended()
+    {
+        if (PHP_VERSION_ID < 70100) {
+            $this->markTestSkipped('This test is for PHP-7.1 and upper only');
+        }
+
+        $constants = ConstVisibilityEnumExtended::getConstants();
+        $this->assertSame(array(
+            'IPUB'  => ConstVisibilityEnumExtended::IPUB,
+            'PUB'   => ConstVisibilityEnumExtended::PUB,
+            'IPUB2' => ConstVisibilityEnumExtended::IPUB2,
+            'PUB2'  => ConstVisibilityEnumExtended::PUB2,
+        ), $constants);
     }
 }

--- a/tests/MabeEnumTest/TestAsset/ConstVisibilityEnum.php
+++ b/tests/MabeEnumTest/TestAsset/ConstVisibilityEnum.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace MabeEnumTest\TestAsset;
+
+use MabeEnum\Enum;
+
+/**
+ * Unit tests for the class MabeEnum\Enum
+ *
+ * @link http://github.com/marc-mabe/php-enum for the canonical source repository
+ * @copyright Copyright (c) 2013 Marc Bennewitz
+ * @license http://github.com/marc-mabe/php-enum/blob/master/LICENSE.txt New BSD License
+ */
+class ConstVisibilityEnum extends Enum
+{
+    const IPUB = 'indirect public';
+    public const PUB = 'public';
+    protected const PRO = 'protected';
+    private const PRI = 'private';
+}

--- a/tests/MabeEnumTest/TestAsset/ConstVisibilityEnumExtended.php
+++ b/tests/MabeEnumTest/TestAsset/ConstVisibilityEnumExtended.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace MabeEnumTest\TestAsset;
+
+use MabeEnum\Enum;
+
+/**
+ * Unit tests for the class MabeEnum\Enum
+ *
+ * @link http://github.com/marc-mabe/php-enum for the canonical source repository
+ * @copyright Copyright (c) 2013 Marc Bennewitz
+ * @license http://github.com/marc-mabe/php-enum/blob/master/LICENSE.txt New BSD License
+ */
+class ConstVisibilityEnumExtended extends ConstVisibilityEnum
+{
+    const IPUB2 = 'indirect public extended';
+    public const PUB2 = 'public extended';
+    protected const PRO2 = 'protected extended';
+    private const PRI2 = 'private extended';
+}


### PR DESCRIPTION
PHP-7.1 will support [Class Constant Visibility](https://wiki.php.net/rfc/class_const_visibility)
but should `private` and/or `protected` class constants be part of an enumeration?