### PR TITLE
EnumSet: added getEnumerators(), getNames() and getValues()

### DIFF
--- a/src/EnumSet.php
+++ b/src/EnumSet.php
@@ -241,13 +241,37 @@ class EnumSet implements Iterator, Countable
     }
 
     /**
+     * Get ordinal numbers of the defined enumerators as array
+     * @return int[]
+     */
+    public function getOrdinals()
+    {
+        $ordinals = array();
+        $byteLen  = strlen($this->bitset);
+
+	for ($bytePos = 0; $bytePos < $byteLen; ++$bytePos) {
+            if ($this->bitset[$bytePos] === "\0") {
+                continue; // fast skip null byte
+            }
+
+            for ($bitPos = 0; $bitPos < 8; ++$bitPos) {
+                if ((ord($this->bitset[$bytePos]) & (1 << $bitPos)) !== 0) {
+                    $ordinals[] = $bytePos * 8 + $bitPos;
+                }
+            }
+        }
+
+        return $ordinals;
+    }
+
+    /**
      * Get values of the defined enumerators as array
      * @return null[]|bool[]|int[]|float[]|string[]
      */
     public function getValues()
     {
         $values = array();
-        foreach ($this as $enumerator) {
+        foreach ($this->getEnumerators() as $enumerator) {
             $values[] = $enumerator->getValue();
         }
         return $values;
@@ -260,7 +284,7 @@ class EnumSet implements Iterator, Countable
     public function getNames()
     {
         $names = array();
-        foreach ($this as $enumerator) {
+        foreach ($this->getEnumerators() as $enumerator) {
             $names[] = $enumerator->getName();
         }
         return $names;
@@ -272,9 +296,10 @@ class EnumSet implements Iterator, Countable
      */
     public function getEnumerators()
     {
+        $enumeration = $this->enumeration;
         $enumerators = array();
-        foreach ($this as $enumerator) {
-            $enumerators[] = $enumerator->getName();
+        foreach ($this->getOrdinals() as $ord) {
+            $enumerators[] = $enumeration::getByOrdinal($ord);
         }
         return $enumerators;
     }

--- a/src/EnumSet.php
+++ b/src/EnumSet.php
@@ -241,6 +241,45 @@ class EnumSet implements Iterator, Countable
     }
 
     /**
+     * Get values of the defined enumerators as array
+     * @return null[]|bool[]|int[]|float[]|string[]
+     */
+    public function getValues()
+    {
+        $values = array();
+        foreach ($this as $enumerator) {
+            $values[] = $enumerator->getValue();
+        }
+        return $values;
+    }
+
+    /**
+     * Get names of the defined enumerators as array
+     * @return string[]
+     */
+    public function getNames()
+    {
+        $names = array();
+        foreach ($this as $enumerator) {
+            $names[] = $enumerator->getName();
+        }
+        return $names;
+    }
+
+    /**
+     * Get the defined enumerators as array
+     * @return Enum[]
+     */
+    public function getEnumerators()
+    {
+        $enumerators = array();
+        foreach ($this as $enumerator) {
+            $enumerators[] = $enumerator->getName();
+        }
+        return $enumerators;
+    }
+
+    /**
      * Get binary bitset in little-endian order
      * 
      * @return string

--- a/tests/MabeEnumTest/EnumSetTest.php
+++ b/tests/MabeEnumTest/EnumSetTest.php
@@ -566,4 +566,96 @@ class EnumSetTest extends TestCase
             $this->assertFalse($set1->isSuperset($set2));
         }
     }
+
+    public function testGetOrdinals()
+    {
+        $set = new EnumSet('MabeEnumTest\TestAsset\EnumBasic');
+        $this->assertSame(array(), $set->getOrdinals());
+
+        foreach (EnumBasic::getConstants() as $value) {
+            $set->attach($value);
+        }
+
+        $this->assertSame(range(0, count(EnumBasic::getConstants()) - 1), $set->getOrdinals());
+    }
+
+    public function testGetOrdinalsDoesNotEffectIteratorPosition()
+    {
+        $set = new EnumSet('MabeEnumTest\TestAsset\EnumBasic');
+        $set->attach(EnumBasic::ONE);
+        $set->attach(EnumBasic::TWO);
+        $set->next();
+
+        $set->getOrdinals();
+        $this->assertSame(EnumBasic::TWO, $set->current()->getValue());
+    }
+
+    public function testGetEnumerators()
+    {
+        $set = new EnumSet('MabeEnumTest\TestAsset\EnumBasic');
+        $this->assertSame(array(), $set->getEnumerators());
+
+        foreach (EnumBasic::getConstants() as $value) {
+            $set->attach($value);
+        }
+
+        $this->assertSame(EnumBasic::getEnumerators(), $set->getEnumerators());
+    }
+
+    public function testGetEnumeratorsDoesNotEffectIteratorPosition()
+    {
+        $set = new EnumSet('MabeEnumTest\TestAsset\EnumBasic');
+        $set->attach(EnumBasic::ONE);
+        $set->attach(EnumBasic::TWO);
+        $set->next();
+
+        $set->getEnumerators();
+        $this->assertSame(EnumBasic::TWO, $set->current()->getValue());
+    }
+
+    public function testGetValues()
+    {
+        $set = new EnumSet('MabeEnumTest\TestAsset\EnumBasic');
+        $this->assertSame(array(), $set->getValues());
+
+        foreach (EnumBasic::getConstants() as $value) {
+            $set->attach($value);
+        }
+
+        $this->assertSame(array_values(EnumBasic::getConstants()), $set->getValues());
+    }
+
+    public function testGetValuesDoesNotEffectIteratorPosition()
+    {
+        $set = new EnumSet('MabeEnumTest\TestAsset\EnumBasic');
+        $set->attach(EnumBasic::ONE);
+        $set->attach(EnumBasic::TWO);
+        $set->next();
+
+        $set->getValues();
+        $this->assertSame(EnumBasic::TWO, $set->current()->getValue());
+    }
+
+    public function testGetNames()
+    {
+        $set = new EnumSet('MabeEnumTest\TestAsset\EnumBasic');
+        $this->assertSame(array(), $set->getNames());
+
+        foreach (EnumBasic::getConstants() as $value) {
+            $set->attach($value);
+        }
+
+        $this->assertSame(array_keys(EnumBasic::getConstants()), $set->getNames());
+    }
+
+    public function testGetNamesDoesNotEffectIteratorPosition()
+    {
+        $set = new EnumSet('MabeEnumTest\TestAsset\EnumBasic');
+        $set->attach(EnumBasic::ONE);
+        $set->attach(EnumBasic::TWO);
+        $set->next();
+
+        $set->getNames();
+        $this->assertSame(EnumBasic::TWO, $set->current()->getValue());
+    }
 }


### PR DESCRIPTION
see #62 Add methods to convert a set into an array

* `EnumSet::getEnumerators() : Enum[]`
* `EnumSet::getValues() : scalar[]`
* `EnumSet::getNames() : string[]`

@prolic I decided to use this names to be consistent with the already existing method `Enum::getEnumerators()` and I also return it just as lists so the ordinal number will not be the array key. I analyzed all my use-cases and couldn't find any where the ordinal number as array key is required. On the other hand I have some use-cases where I actually require a simple list. Also it's still simple possible to just use `iterator_to_array($set)` to convert the set into an associative array with ordinal number to enumerator instance.

PS: The same set of methods should also work on `EnumMap` and on `Enum` (as static versions)