### PR TITLE
EnumSet: added methods union(), intersect(), diff() and symDiff()

### DIFF
--- a/src/EnumSet.php
+++ b/src/EnumSet.php
@@ -246,6 +246,106 @@ class EnumSet implements Iterator, Countable
     }
 
     /**
+     * Produce a new set with enumerators from both this and other (this | other)
+     * @param EnumSet ...$other Other EnumSet(s) of the same enumeration to produce the union
+     * @return EnumSet
+     */
+    public function union(EnumSet $other)
+    {
+        $bitset = $this->bitset;
+        foreach (func_get_args() as $other) {
+            if (!$other instanceof self || $this->enumeration !== $other->enumeration) {
+                throw new InvalidArgumentException(sprintf(
+                    "Others should be an instance of %s of the same enumeration as this %s",
+                    __CLASS__,
+                    $this->enumeration
+                ));
+            }
+
+            $bitset |= $other->bitset;
+        }
+
+        $clone = clone $this;
+        $clone->bitset = $bitset;
+        return $clone;
+    }
+
+    /**
+     * Produce a new set with enumerators common to both this and other (this & other)
+     * @param EnumSet ...$other Other EnumSet(s) of the same enumeration to produce the union
+     * @return EnumSet
+     */
+    public function intersect(EnumSet $other)
+    {
+        $bitset = $this->bitset;
+        foreach (func_get_args() as $other) {
+            if (!$other instanceof self || $this->enumeration !== $other->enumeration) {
+                throw new InvalidArgumentException(sprintf(
+                    "Others should be an instance of %s of the same enumeration as this %s",
+                    __CLASS__,
+                    $this->enumeration
+                ));
+            }
+
+            $bitset &= $other->bitset;
+        }
+
+        $clone = clone $this;
+        $clone->bitset = $bitset;
+        return $clone;
+    }
+
+    /**
+     * Produce a new set with enumerators in this but not in other (this - other)
+     * @param EnumSet ...$other Other EnumSet(s) of the same enumeration to produce the union
+     * @return EnumSet
+     */
+    public function diff(EnumSet $other)
+    {
+        $bitset = '';
+        foreach (func_get_args() as $other) {
+            if (!$other instanceof self || $this->enumeration !== $other->enumeration) {
+                throw new InvalidArgumentException(sprintf(
+                    "Others should be an instance of %s of the same enumeration as this %s",
+                    __CLASS__,
+                    $this->enumeration
+                ));
+            }
+
+            $bitset |= $other->bitset;
+        }
+
+        $clone = clone $this;
+        $clone->bitset = $this->bitset & ~$bitset;
+        return $clone;
+    }
+
+    /**
+     * Produce a new set with enumerators in either this and other but not in both (this ^ (other | other))
+     * @param EnumSet ...$other Other EnumSet(s) of the same enumeration to produce the union
+     * @return EnumSet
+     */
+    public function symDiff(EnumSet $other)
+    {
+        $bitset = '';
+        foreach (func_get_args() as $other) {
+            if (!$other instanceof self || $this->enumeration !== $other->enumeration) {
+                throw new InvalidArgumentException(sprintf(
+                    "Others should be an instance of %s of the same enumeration as this %s",
+                    __CLASS__,
+                    $this->enumeration
+                ));
+            }
+
+            $bitset |= $other->bitset;
+        }
+
+        $clone = clone $this;
+        $clone->bitset = $this->bitset ^ $bitset;
+        return $clone;
+    }
+
+    /**
      * Get ordinal numbers of the defined enumerators as array
      * @return int[]
      */

--- a/tests/MabeEnumTest/EnumSetTest.php
+++ b/tests/MabeEnumTest/EnumSetTest.php
@@ -672,4 +672,134 @@ class EnumSetTest extends TestCase
         $set->getNames();
         $this->assertSame(EnumBasic::TWO, $set->current()->getValue());
     }
+
+    public function testUnion()
+    {
+        $set1 = new EnumSet('MabeEnumTest\TestAsset\EnumBasic');
+        $set1->attach(EnumBasic::ONE);
+        $set1->attach(EnumBasic::TWO);
+
+        $set2 = new EnumSet('MabeEnumTest\TestAsset\EnumBasic');
+        $set2->attach(EnumBasic::TWO);
+        $set2->attach(EnumBasic::THREE);
+
+        $set3 = new EnumSet('MabeEnumTest\TestAsset\EnumBasic');
+        $set3->attach(EnumBasic::THREE);
+        $set3->attach(EnumBasic::FOUR);
+
+        $rs = $set1->union($set2, $set3);
+        $this->assertSame(array(
+            EnumBasic::ONE,
+            EnumBasic::TWO,
+            EnumBasic::THREE,
+            EnumBasic::FOUR,
+        ), $rs->getValues());
+    }
+
+    public function testUnionThrowsInvalidArgumentException()
+    {
+        $set1 = new EnumSet('MabeEnumTest\TestAsset\EnumBasic');
+        $set2 = new EnumSet('MabeEnumTest\TestAsset\Enum32');
+
+        $this->setExpectedException('InvalidArgumentException');
+        $set1->union($set2);
+    }
+
+    public function testIntersect()
+    {
+        $set1 = new EnumSet('MabeEnumTest\TestAsset\EnumBasic');
+        $set1->attach(EnumBasic::ONE);
+        $set1->attach(EnumBasic::TWO);
+        $set1->attach(EnumBasic::THREE);
+
+        $set2 = new EnumSet('MabeEnumTest\TestAsset\EnumBasic');
+        $set2->attach(EnumBasic::TWO);
+        $set2->attach(EnumBasic::THREE);
+        $set2->attach(EnumBasic::FOUR);
+
+        $set3 = new EnumSet('MabeEnumTest\TestAsset\EnumBasic');
+        $set3->attach(EnumBasic::THREE);
+        $set3->attach(EnumBasic::FOUR);
+        $set3->attach(EnumBasic::FIVE);
+
+        $rs = $set1->intersect($set2, $set3);
+        $this->assertSame(array(
+            EnumBasic::THREE,
+        ), $rs->getValues());
+    }
+
+    public function testIntersectThrowsInvalidArgumentException()
+    {
+        $set1 = new EnumSet('MabeEnumTest\TestAsset\EnumBasic');
+        $set2 = new EnumSet('MabeEnumTest\TestAsset\Enum32');
+
+        $this->setExpectedException('InvalidArgumentException');
+        $set1->intersect($set2);
+    }
+
+    public function testDiff()
+    {
+        $set1 = new EnumSet('MabeEnumTest\TestAsset\EnumBasic');
+        $set1->attach(EnumBasic::ONE);
+        $set1->attach(EnumBasic::TWO);
+        $set1->attach(EnumBasic::THREE);
+
+        $set2 = new EnumSet('MabeEnumTest\TestAsset\EnumBasic');
+        $set2->attach(EnumBasic::TWO);
+        $set2->attach(EnumBasic::THREE);
+        $set2->attach(EnumBasic::FOUR);
+
+        $set3 = new EnumSet('MabeEnumTest\TestAsset\EnumBasic');
+        $set3->attach(EnumBasic::THREE);
+        $set3->attach(EnumBasic::FOUR);
+        $set3->attach(EnumBasic::FIVE);
+
+        $rs = $set1->diff($set2, $set3);
+        $this->assertSame(array(
+            EnumBasic::ONE,
+        ), $rs->getValues());
+    }
+
+    public function testDiffThrowsInvalidArgumentException()
+    {
+        $set1 = new EnumSet('MabeEnumTest\TestAsset\EnumBasic');
+        $set2 = new EnumSet('MabeEnumTest\TestAsset\Enum32');
+
+        $this->setExpectedException('InvalidArgumentException');
+        $set1->diff($set2);
+    }
+
+    public function testSymDiff()
+    {
+        $set1 = new EnumSet('MabeEnumTest\TestAsset\EnumBasic');
+        $set1->attach(EnumBasic::ONE);
+        $set1->attach(EnumBasic::TWO);
+        $set1->attach(EnumBasic::THREE);
+
+        $set2 = new EnumSet('MabeEnumTest\TestAsset\EnumBasic');
+        $set2->attach(EnumBasic::TWO);
+        $set2->attach(EnumBasic::THREE);
+        $set2->attach(EnumBasic::FOUR);
+
+        $set3 = new EnumSet('MabeEnumTest\TestAsset\EnumBasic');
+        $set3->attach(EnumBasic::THREE);
+        $set3->attach(EnumBasic::FOUR);
+        $set3->attach(EnumBasic::FIVE);
+
+        $rs = $set1->symDiff($set2, $set3);
+        $this->assertSame(array(
+            EnumBasic::ONE,
+            EnumBasic::FOUR,
+            EnumBasic::FIVE,
+        ), $rs->getValues());
+    }
+
+    public function testSymDiffThrowsInvalidArgumentException()
+    {
+        $set1 = new EnumSet('MabeEnumTest\TestAsset\EnumBasic');
+        $set2 = new EnumSet('MabeEnumTest\TestAsset\Enum32');
+
+        $this->setExpectedException('InvalidArgumentException');
+        $set1->symDiff($set2);
+    }
 }


### PR DESCRIPTION
see #62 

These methods create a clone of `$this` and change the bitset to not depend on implementation details of extended classes. 

* `EnumSet::union(EnumSet ...$others) : EnumSet`
* `EnumSet::intersect(EnumSet ...$others) : EnumSet`
* `EnumSet::diff(EnumSet ...$others) : EnumSet`
* `EnumSet::symDiff(EnumSet ...$others) : EnumSet`