### PR TITLE
Added additional check to Enum::is() to return TRUE …

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,8 +271,9 @@ class CardinalDirection extends Enum implements Serializable
 $north1 = CardinalDirection::NORTH();
 $north2 = unserialize(serialize($north1));
 
-// The following could be FALSE as described above
-var_dump($north1 === $north2);
+var_dump($north1 === $north2);  // returns FALSE as described above
+var_dump($north1->is($north2)); // returns TRUE - this way the two instances are treated equal
+var_dump($north2->is($north1)); // returns TRUE - equality works in both directions
 ```
 
 # Why not `SplEnum`

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -146,7 +146,13 @@ abstract class Enum
      */
     final public function is($enumerator)
     {
-        return $this === $enumerator || $this->value === $enumerator;
+        return $this === $enumerator || $this->value === $enumerator
+
+            // The following additional conditions are required only because of the issue of serializable singletons
+            || ($enumerator instanceof static
+                && get_class($enumerator) === get_called_class()
+                && $enumerator->value === $this->value
+            );
     }
 
     /**

--- a/tests/MabeEnumTest/EnumTest.php
+++ b/tests/MabeEnumTest/EnumTest.php
@@ -8,6 +8,7 @@ use MabeEnumTest\TestAsset\EnumAmbiguous;
 use MabeEnumTest\TestAsset\EnumExtendedAmbiguous;
 use MabeEnumTest\TestAsset\ConstVisibilityEnum;
 use MabeEnumTest\TestAsset\ConstVisibilityEnumExtended;
+use MabeEnumTest\TestAsset\SerializableEnum;
 use PHPUnit_Framework_TestCase as TestCase;
 use ReflectionClass;
 
@@ -284,5 +285,18 @@ class EnumTest extends TestCase
             'IPUB2' => ConstVisibilityEnumExtended::IPUB2,
             'PUB2'  => ConstVisibilityEnumExtended::PUB2,
         ), $constants);
+    }
+
+    public function testIsSerializableIssue()
+    {
+        if (PHP_VERSION_ID < 50400) {
+            $this->markTestSkipped('This test is for PHP-5.4 and upper only');
+        }
+
+        $enum1 = SerializableEnum::INT();
+        $enum2 = unserialize(serialize($enum1));
+
+        $this->assertFalse($enum1 === $enum2, 'Wrong test implementation');
+        $this->assertTrue($enum1->is($enum2), 'Two different instances of exact the same enumerator should be equal');
     }
 }


### PR DESCRIPTION
… in cases both enumerators are the same but of different instances. This can happen because of the issue with serializable singletons