### PR TITLE
Added static Enum::getValues(), Enum::getNames() and Enum::getOrdinals()

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -257,6 +257,36 @@ abstract class Enum
     }
 
     /**
+     * Get a list of enumerator values ordered by ordinal number
+     *
+     * @return mixed[]
+     */
+    final public static function getValues()
+    {
+        return array_values(self::detectConstants(get_called_class()));
+    }
+
+    /**
+     * Get a list of enumerator names ordered by ordinal number
+     *
+     * @return string[]
+     */
+    final public static function getNames()
+    {
+        return array_keys(self::detectConstants(get_called_class()));
+    }
+    /*
+     * Get a list of enumerator ordinal numbers
+     *
+     * @return int[]
+     */
+    final public static function getOrdinals()
+    {
+        $count = count(self::detectConstants(get_called_class()));
+        return $count === 0 ? array() : range(0, $count - 1);
+    }
+
+    /**
      * Get all available constants of the called class
      *
      * @return array

--- a/tests/MabeEnumTest/EnumTest.php
+++ b/tests/MabeEnumTest/EnumTest.php
@@ -126,6 +126,45 @@ class EnumTest extends TestCase
         }
     }
 
+    public function testGetValues()
+    {
+        $expectedValues = array_values(EnumInheritance::getConstants());
+        $values         = EnumInheritance::getValues();
+        $count          = count($values);
+
+        $this->assertSame(count($expectedValues), $count);
+        for ($i = 0; $i < $count; ++$i) {
+            $this->assertArrayHasKey($i, $values);
+            $this->assertSame($expectedValues[$i], $values[$i]);
+        }
+    }
+
+    public function testGetNames()
+    {
+        $expectedNames = array_keys(EnumInheritance::getConstants());
+        $names         = EnumInheritance::getNames();
+        $count         = count($names);
+
+        $this->assertSame(count($expectedNames), $count);
+        for ($i = 0; $i < $count; ++$i) {
+            $this->assertArrayHasKey($i, $names);
+            $this->assertSame($expectedNames[$i], $names[$i]);
+        }
+    }
+
+    public function testGetOrdinals()
+    {
+        $constants = EnumInheritance::getConstants();
+        $ordinals  = EnumInheritance::getOrdinals();
+        $count     = count($ordinals);
+
+        $this->assertSame(count($constants), $count);
+        for ($i = 0; $i < $count; ++$i) {
+            $this->assertArrayHasKey($i, $ordinals);
+            $this->assertSame($i, $ordinals[$i]);
+        }
+    }
+
     public function testGetAllValues()
     {
         $constants = EnumBasic::getConstants();


### PR DESCRIPTION
… to be consistent with the object methods of EnumSet.