### PR TITLE
deprecated Enum::clear()

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -239,6 +239,7 @@ abstract class Enum
      * NOTE: This can break singleton behavior ... use it with caution!
      *
      * @return void
+     * @deprecated
      */
     final public static function clear()
     {

--- a/tests/MabeEnumTest/EnumTest.php
+++ b/tests/MabeEnumTest/EnumTest.php
@@ -20,12 +20,6 @@ use ReflectionClass;
  */
 class EnumTest extends TestCase
 {
-    public function setUp()
-    {
-        EnumBasic::clear();
-        EnumInheritance::clear();
-    }
-
     public function testGetNameReturnsConstantNameOfCurrentValue()
     {
         $enum = EnumBasic::get(EnumBasic::ONE);


### PR DESCRIPTION
This static method was only for testing and on the same time it broke singleton behavior is used somewhere else as in this library tests. This removed all unnecessary usagas of it and rewrote necessary usages with reflection. So this cind of internal method is no longer needed and can be removed.