### PR TITLE
mv Enum::getBy[Name|Ordinal]() to Enum::by[Name|Ordinal]() & add Enum::byValue()

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ class UserStatus extends Enum
 // different ways to instantiate an enumerator
 $status = UserStatus::get(UserStatus::ACTIVE);
 $status = UserStatus::ACTIVE();
-$status = UserStatus::getByName('ACTIVE');
-$status = UserStatus::getByOrdinal(1);
+$status = UserStatus::byName('ACTIVE');
+$status = UserStatus::byOrdinal(1);
 
 // available methods to get the selected entry
 $status->getValue();   // returns the selected constant value

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -163,6 +163,19 @@ abstract class Enum
             return $value;
         }
 
+        return static::byValue($value);
+    }
+
+    /**
+     * Get an enumerator instance by the given value
+     *
+     * @param mixed $value
+     * @return static
+     * @throws InvalidArgumentException On an unknwon or invalid value
+     * @throws LogicException           On ambiguous constant values
+     */
+    final public static function byValue($value)
+    {
         $class     = get_called_class();
         $constants = self::detectConstants($class);
         $name      = array_search($value, $constants, true);
@@ -188,7 +201,7 @@ abstract class Enum
      * @throws InvalidArgumentException On an invalid or unknown name
      * @throws LogicException           On ambiguous values
      */
-    final public static function getByName($name)
+    final public static function byName($name)
     {
         $name  = (string) $name;
         $class = get_called_class();
@@ -212,7 +225,7 @@ abstract class Enum
      * @throws InvalidArgumentException On an invalid ordinal number
      * @throws LogicException           On ambiguous values
      */
-    final public static function getByOrdinal($ordinal)
+    final public static function byOrdinal($ordinal)
     {
         $ordinal   = (int) $ordinal;
         $class     = get_called_class();
@@ -231,6 +244,34 @@ abstract class Enum
         }
 
         return self::$instances[$class][$name] = new $class(current($item), $ordinal);
+    }
+
+    /**
+     * Get an enumerator instance by the given name
+     *
+     * @param string $name The name of the enumerator
+     * @return static
+     * @throws InvalidArgumentException On an invalid or unknown name
+     * @throws LogicException           On ambiguous values
+     * @deprecated
+     */
+    final public static function getByName($name)
+    {
+        return static::byName($name);
+    }
+
+    /**
+     * Get an enumeration instance by the given ordinal number
+     *
+     * @param int $ordinal The ordinal number or the enumerator
+     * @return static
+     * @throws InvalidArgumentException On an invalid ordinal number
+     * @throws LogicException           On ambiguous values
+     * @deprecated
+     */
+    final public static function getByOrdinal($ordinal)
+    {
+        return static::byOrdinal($ordinal);
     }
 
     /**
@@ -253,7 +294,7 @@ abstract class Enum
      */
     final public static function getEnumerators()
     {
-        return array_map('self::getByName', array_keys(self::detectConstants(get_called_class())));
+        return array_map('self::byName', array_keys(self::detectConstants(get_called_class())));
     }
 
     /**
@@ -353,6 +394,6 @@ abstract class Enum
      */
     final public static function __callStatic($method, array $args)
     {
-        return self::getByName($method);
+        return self::byName($method);
     }
 }

--- a/src/EnumSet.php
+++ b/src/EnumSet.php
@@ -125,7 +125,7 @@ class EnumSet implements Iterator, Countable
     {
         if ($this->valid()) {
             $enumeration = $this->enumeration;
-            return $enumeration::getByOrdinal($this->ordinal);
+            return $enumeration::byOrdinal($this->ordinal);
         }
 
         return null;
@@ -376,7 +376,7 @@ class EnumSet implements Iterator, Countable
         $enumeration = $this->enumeration;
         $values      = array();
         foreach ($this->getOrdinals() as $ord) {
-            $values[] = $enumeration::getByOrdinal($ord)->getValue();
+            $values[] = $enumeration::byOrdinal($ord)->getValue();
         }
         return $values;
     }
@@ -390,7 +390,7 @@ class EnumSet implements Iterator, Countable
         $enumeration = $this->enumeration;
         $names       = array();
         foreach ($this->getOrdinals() as $ord) {
-            $names[] = $enumeration::getByOrdinal($ord)->getName();
+            $names[] = $enumeration::byOrdinal($ord)->getName();
         }
         return $names;
     }
@@ -404,7 +404,7 @@ class EnumSet implements Iterator, Countable
         $enumeration = $this->enumeration;
         $enumerators = array();
         foreach ($this->getOrdinals() as $ord) {
-            $enumerators[] = $enumeration::getByOrdinal($ord);
+            $enumerators[] = $enumeration::byOrdinal($ord);
         }
         return $enumerators;
     }

--- a/tests/MabeEnumTest/EnumSetTest.php
+++ b/tests/MabeEnumTest/EnumSetTest.php
@@ -174,7 +174,7 @@ class EnumSetTest extends TestCase
     public function testIterateOutOfRangeIfLastOrdinalEnumIsSet()
     {
         $enumSet = new EnumSet('MabeEnumTest\TestAsset\EnumBasic');
-        $enum    = EnumBasic::getByOrdinal(count(EnumBasic::getConstants()) - 1);
+        $enum    = EnumBasic::byOrdinal(count(EnumBasic::getConstants()) - 1);
 
         $enumSet->attach($enum);
         $enumSet->rewind();
@@ -246,7 +246,7 @@ class EnumSetTest extends TestCase
     {
         $enum = new EnumSet('MabeEnumTest\TestAsset\Enum65');
 
-        $this->assertNull($enum->attach(Enum65::getByOrdinal(64)));
+        $this->assertNull($enum->attach(Enum65::byOrdinal(64)));
         $enum->next();
         $this->assertTrue($enum->valid());
     }

--- a/tests/MabeEnumTest/EnumTest.php
+++ b/tests/MabeEnumTest/EnumTest.php
@@ -159,7 +159,7 @@ class EnumTest extends TestCase
 
     public function testInstantiateUsingOrdinalNumber()
     {
-        $enum = EnumInheritance::getByOrdinal(16);
+        $enum = EnumInheritance::byOrdinal(16);
         $this->assertSame(16, $enum->getOrdinal());
         $this->assertSame('INHERITANCE', $enum->getName());
     }
@@ -167,12 +167,12 @@ class EnumTest extends TestCase
     public function testInstantiateUsingInvalidOrdinalNumberThrowsInvalidArgumentException()
     {
         $this->setExpectedException('InvalidArgumentException');
-        EnumInheritance::getByOrdinal(17);
+        EnumInheritance::byOrdinal(17);
     }
 
     public function testInstantiateByName()
     {
-        $enum = EnumInheritance::getByName('ONE');
+        $enum = EnumInheritance::byName('ONE');
         $this->assertInstanceOf('MabeEnumTest\TestAsset\EnumInheritance', $enum);
         $this->assertSame(EnumInheritance::ONE, $enum->getValue());
     }
@@ -180,7 +180,7 @@ class EnumTest extends TestCase
     public function testInstantiateByUnknownNameThrowsInvalidArgumentException()
     {
         $this->setExpectedException('InvalidArgumentException');
-        EnumInheritance::getByName('UNKNOWN');
+        EnumInheritance::byName('UNKNOWN');
     }
 
     public function testInstantiateUsingMagicMethod()


### PR DESCRIPTION
This is just for consistency to differ the methods of getting something out of an enumeration/set/enumerator using `get*()` with the methods for accessing an enumerator (`Enum::by*()`).

The method `Enum::get($valueOrInstance)` still exists but I added the method `Enum::byValue($value)` which doesn't allow an already instantiated enumerator as argument.
-> So for consistency the method `Enum::get($valueOrInstance)` doesn't really follow this naming but calling it something like `byValueOrInstance` sounds stange to me and also this is a widely used method that I wouldn't like to rename.

@prolic Do you think this makes sense even with the given BC later on removing deprecated methods?
