### PR TITLE
fixed logic of 'truncate out-of-range bits of last byte'

### DIFF
--- a/src/EnumSet.php
+++ b/src/EnumSet.php
@@ -449,7 +449,7 @@ class EnumSet implements Iterator, Countable
         if ($lastByteMaxOrd === 0) {
             $this->bitset = $bitset;
         } else {
-            $lastByte     = chr($lastByteMaxOrd) & $bitset[$size - 1];
+            $lastByte     = chr((1 << $lastByteMaxOrd) - 1) & $bitset[$size - 1];
             $this->bitset = substr($bitset, 0, -1) . $lastByte;
         }
 

--- a/tests/MabeEnumTest/EnumSetTest.php
+++ b/tests/MabeEnumTest/EnumSetTest.php
@@ -9,6 +9,7 @@ use MabeEnumTest\TestAsset\EnumInheritance;
 use MabeEnumTest\TestAsset\Enum32;
 use MabeEnumTest\TestAsset\Enum64;
 use MabeEnumTest\TestAsset\Enum65;
+use MabeEnumTest\TestAsset\Enum66;
 use PHPUnit_Framework_TestCase as TestCase;
 
 /**
@@ -370,8 +371,11 @@ class EnumSetTest extends TestCase
 
     public function testSetBinaryBitsetLeTruncateHighBits()
     {
-        $enumSet = new EnumSet('MabeEnumTest\TestAsset\Enum65');
-        foreach (Enum65::getEnumerators() as $enumerator) {
+        // using Enum66 to make sure the max. ordinal number gets converted into a bitset
+        // Enum65 has max. ordinal number of 1 of the last byte. -> 00000001
+        // Enum66 has max. ordinal number of 2 of the last byte. -> 00000011
+        $enumSet = new EnumSet('MabeEnumTest\TestAsset\Enum66');
+        foreach (Enum66::getEnumerators() as $enumerator) {
             $enumSet->attach($enumerator);
         }
 

--- a/tests/MabeEnumTest/TestAsset/Enum66.php
+++ b/tests/MabeEnumTest/TestAsset/Enum66.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace MabeEnumTest\TestAsset;
+
+use MabeEnum\Enum;
+
+/**
+ * Unit tests for the class MabeEnum\Enum
+ *
+ * @link http://github.com/marc-mabe/php-enum for the canonical source repository
+ * @copyright Copyright (c) 2013 Marc Bennewitz
+ * @license http://github.com/marc-mabe/php-enum/blob/master/LICENSE.txt New BSD License
+ */
+class Enum66 extends Enum65
+{
+    const SIXTYSIX = 66;
+}


### PR DESCRIPTION
... in EnumSet::setBinaryBitset*()