### PR TITLE
Optimized EnumSet::count() and EnumSet::getOrdinals()

### DIFF
--- a/src/EnumSet.php
+++ b/src/EnumSet.php
@@ -184,8 +184,9 @@ class EnumSet implements Iterator, Countable
                 continue; // fast skip null byte
             }
 
+            $ord = ord($this->bitset[$bytePos]);
             for ($bitPos = 0; $bitPos < 8; ++$bitPos) {
-                if ((ord($this->bitset[$bytePos]) & (1 << $bitPos)) !== 0) {
+                if ($ord & (1 << $bitPos)) {
                     ++$count;
                 }
             }
@@ -347,8 +348,9 @@ class EnumSet implements Iterator, Countable
                 continue; // fast skip null byte
             }
 
+            $ord = ord($this->bitset[$bytePos]);
             for ($bitPos = 0; $bitPos < 8; ++$bitPos) {
-                if ((ord($this->bitset[$bytePos]) & (1 << $bitPos)) !== 0) {
+                if ($ord & (1 << $bitPos)) {
                     $ordinals[] = $bytePos * 8 + $bitPos;
                 }
             }


### PR DESCRIPTION
```
$before:
+----------------+------------------+--------+--------+------+-----+------------+---------+---------+---------+---------+---------+--------+------------+
| benchmark      | subject          | groups | params | revs | its | mem_peak   | best    | mean    | mode    | worst   | stdev   | rstdev | diff       |
+----------------+------------------+--------+--------+------+-----+------------+---------+---------+---------+---------+---------+--------+------------+
| EnumSet66Bench | benchGetOrdinals |        | []     | 2000 | 25  | 1,094,776b | 7.078μs | 7.190μs | 7.133μs | 7.449μs | 0.099μs | 1.38%  | +1,409.27% |
| EnumSet32Bench | benchGetOrdinals |        | []     | 2000 | 25  | 1,032,616b | 3.251μs | 3.334μs | 3.318μs | 3.452μs | 0.047μs | 1.40%  | +599.78%   |
+----------------+------------------+--------+--------+------+-----+------------+---------+---------+---------+---------+---------+--------+------------+

$after:
+----------------+------------------+--------+--------+------+-----+------------+---------+---------+---------+---------+---------+--------+----------+
| benchmark      | subject          | groups | params | revs | its | mem_peak   | best    | mean    | mode    | worst   | stdev   | rstdev | diff     |
+----------------+------------------+--------+--------+------+-----+------------+---------+---------+---------+---------+---------+--------+----------+
| EnumSet66Bench | benchGetOrdinals |        | []     | 2000 | 25  | 1,094,856b | 4.286μs | 4.469μs | 4.507μs | 4.640μs | 0.098μs | 2.19%  | +842.34% |
| EnumSet32Bench | benchGetOrdinals |        | []     | 2000 | 25  | 1,032,696b | 2.059μs | 2.139μs | 2.160μs | 2.226μs | 0.048μs | 2.25%  | +350.96% |
+----------------+------------------+--------+--------+------+-----+------------+---------+---------+---------+---------+---------+--------+----------+
```