### PR TITLE
removed enumerator value support for EnumMap::getHash() 

### DIFF
--- a/src/EnumMap.php
+++ b/src/EnumMap.php
@@ -88,18 +88,6 @@ class EnumMap extends SplObjectStorage
     }
 
     /**
-     * Get a unique identifier for the given enumerator
-     * @param Enum|null|boolean|int|float|string $enumerator
-     * @return string
-     * @throws InvalidArgumentException On an invalid given enumerator
-     */
-    public function getHash($enumerator)
-    {
-        $enumeration = $this->enumeration;
-        return spl_object_hash($enumeration::get($enumerator));
-    }
-
-    /**
      * Test if the given enumerator exists
      * @param Enum|null|boolean|int|float|string $enumerator
      * @return boolean

--- a/tests/MabeEnumTest/EnumMapTest.php
+++ b/tests/MabeEnumTest/EnumMapTest.php
@@ -62,13 +62,11 @@ class EnumMapTest extends TestCase
         $this->assertNull($enumMap->attach($enum1, $value1));
         $this->assertTrue($enumMap->contains($enum1));
         $this->assertSame($value1, $enumMap[$enum1]);
-        $this->assertSame(spl_object_hash(EnumBasic::ONE()), $enumMap->getHash($enum1));
 
         $this->assertFalse($enumMap->contains($enum2));
         $this->assertNull($enumMap->attach($enum2, $value2));
         $this->assertTrue($enumMap->contains($enum2));
         $this->assertSame($value2, $enumMap[$enum2]);
-        $this->assertSame(spl_object_hash(EnumBasic::TWO()), $enumMap->getHash($enum2));
 
         $this->assertNull($enumMap->detach($enum1));
         $this->assertFalse($enumMap->contains($enum1));


### PR DESCRIPTION
... and use PHP build-in hash impl. for performance reasons.

```
Current master:
+--------------+----------------------------------+--------+--------+------+-----+------------+----------+-----------+-----------+-----------+---------+--------+--------------+
| benchmark    | subject                          | groups | params | revs | its | mem_peak   | best     | mean      | mode      | worst     | stdev   | rstdev | diff         |
+--------------+----------------------------------+--------+--------+------+-----+------------+----------+-----------+-----------+-----------+---------+--------+--------------+
| EnumMapBench | benchOffsetSetEnumerator         |        | []     | 2000 | 25  | 1,113,928b | 61.552μs | 63.679μs  | 62.264μs  | 66.677μs  | 1.523μs | 2.39%  | +91,525.06%  |
| EnumMapBench | benchOffsetSetValue              |        | []     | 2000 | 25  | 1,113,920b | 97.081μs | 101.126μs | 100.256μs | 104.996μs | 1.892μs | 1.87%  | +145,404.69% |
| EnumMapBench | benchOffsetUnsetEnumerator       |        | []     | 2000 | 25  | 1,097,480b | 57.808μs | 59.969μs  | 59.895μs  | 62.840μs  | 1.234μs | 2.06%  | +86,186.04%  |
| EnumMapBench | benchOffsetUnsetValue            |        | []     | 2000 | 25  | 1,097,472b | 93.258μs | 95.952μs  | 96.015μs  | 99.521μs  | 1.202μs | 1.25%  | +137,960.52% |
| EnumMapBench | benchOffsetExistsEnumeratorTrue  |        | []     | 2000 | 25  | 1,097,480b | 59.933μs | 61.908μs  | 62.103μs  | 63.937μs  | 0.992μs | 1.60%  | +88,976.46%  |
| EnumMapBench | benchOffsetExistsEnumeratorFalse |        | []     | 2000 | 25  | 1,097,488b | 60.089μs | 61.905μs  | 61.466μs  | 64.783μs  | 1.236μs | 2.00%  | +88,972.23%  |
| EnumMapBench | benchOffsetExistsValueTrue       |        | []     | 2000 | 25  | 1,097,480b | 96.021μs | 99.357μs  | 98.720μs  | 102.953μs | 2.003μs | 2.02%  | +142,859.45% |
| EnumMapBench | benchOffsetExistsValueFalse      |        | []     | 2000 | 25  | 1,097,480b | 97.206μs | 100.347μs | 99.428μs  | 104.440μs | 2.189μs | 2.18%  | +144,284.37% |
| EnumMapBench | benchIterateFull                 |        | []     | 2000 | 25  | 1,097,472b | 23.543μs | 24.440μs  | 24.566μs  | 25.530μs  | 0.571μs | 2.34%  | +35,066.10%  |
| EnumMapBench | benchIterateEmpty                |        | []     | 2000 | 25  | 1,097,472b | 0.205μs  | 0.210μs   | 0.208μs   | 0.220μs   | 0.004μs | 1.92%  | +201.70%     |
| EnumMapBench | benchCountFull                   |        | []     | 2000 | 25  | 1,097,464b | 0.069μs  | 0.070μs   | 0.069μs   | 0.072μs   | 0.001μs | 1.10%  | 0.00%        |
| EnumMapBench | benchCountEmpty                  |        | []     | 2000 | 25  | 1,097,464b | 0.070μs  | 0.072μs   | 0.072μs   | 0.076μs   | 0.002μs | 2.19%  | +4.26%       |
+--------------+----------------------------------+--------+--------+------+-----+------------+----------+-----------+-----------+-----------+---------+--------+--------------+

This branch:
+--------------+----------------------------------+--------+--------+------+-----+------------+----------+----------+----------+----------+---------+--------+-------------+
| benchmark    | subject                          | groups | params | revs | its | mem_peak   | best     | mean     | mode     | worst    | stdev   | rstdev | diff        |
+--------------+----------------------------------+--------+--------+------+-----+------------+----------+----------+----------+----------+---------+--------+-------------+
| EnumMapBench | benchOffsetSetEnumerator         |        | []     | 2000 | 25  | 1,095,728b | 27.341μs | 28.717μs | 28.609μs | 29.976μs | 0.608μs | 2.12%  | +40,233.12% |
| EnumMapBench | benchOffsetSetValue              |        | []     | 2000 | 25  | 1,095,720b | 54.482μs | 56.606μs | 56.707μs | 59.086μs | 1.140μs | 2.01%  | +79,403.20% |
| EnumMapBench | benchOffsetUnsetEnumerator       |        | []     | 2000 | 25  | 1,095,728b | 23.399μs | 24.498μs | 24.753μs | 25.721μs | 0.713μs | 2.91%  | +34,307.98% |
| EnumMapBench | benchOffsetUnsetValue            |        | []     | 2000 | 25  | 1,095,720b | 52.179μs | 53.982μs | 53.926μs | 55.334μs | 0.812μs | 1.50%  | +75,717.30% |
| EnumMapBench | benchOffsetExistsEnumeratorTrue  |        | []     | 2000 | 25  | 1,095,728b | 26.071μs | 26.798μs | 26.500μs | 27.977μs | 0.564μs | 2.11%  | +37,538.01% |
| EnumMapBench | benchOffsetExistsEnumeratorFalse |        | []     | 2000 | 25  | 1,095,736b | 25.710μs | 26.607μs | 26.235μs | 27.387μs | 0.487μs | 1.83%  | +37,269.04% |
| EnumMapBench | benchOffsetExistsValueTrue       |        | []     | 2000 | 25  | 1,095,728b | 55.937μs | 57.018μs | 56.621μs | 58.565μs | 0.701μs | 1.23%  | +79,981.57% |
| EnumMapBench | benchOffsetExistsValueFalse      |        | []     | 2000 | 25  | 1,095,728b | 56.032μs | 56.851μs | 56.621μs | 58.184μs | 0.539μs | 0.95%  | +79,746.52% |
| EnumMapBench | benchIterateFull                 |        | []     | 2000 | 25  | 1,095,720b | 23.518μs | 23.947μs | 23.648μs | 25.022μs | 0.459μs | 1.92%  | +33,533.34% |
| EnumMapBench | benchIterateEmpty                |        | []     | 2000 | 25  | 1,095,720b | 0.208μs  | 0.212μs  | 0.210μs  | 0.218μs  | 0.003μs | 1.38%  | +197.05%    |
| EnumMapBench | benchCountFull                   |        | []     | 2000 | 25  | 1,095,712b | 0.069μs  | 0.071μs  | 0.072μs  | 0.075μs  | 0.002μs | 2.48%  | 0.00%       |
| EnumMapBench | benchCountEmpty                  |        | []     | 2000 | 25  | 1,095,712b | 0.072μs  | 0.073μs  | 0.072μs  | 0.077μs  | 0.002μs | 2.17%  | +2.98%      |
+--------------+----------------------------------+--------+--------+------+-----+------------+----------+----------+----------+----------+---------+--------+-------------+
```