### PR TITLE
Refactor EnumMap - fixes #91

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,15 +42,13 @@ class UserStatus extends Enum
     const ACTIVE   = 'a';
     const DELETED  = 'd';
 
-    // all scalar datatypes are supported
+    // all scalar data types and arrays are supported as enumerator values
     const NIL     = null;
     const BOOLEAN = true;
     const INT     = 1234;
     const STR     = 'string';
     const FLOAT   = 0.123;
-
-    // Arrays are supported since PHP-5.6
-    const ARR = array('this', 'is', array('an', 'array'));
+    const ARR     = ['this', 'is', ['an', 'array']];
 
     // Enumerators will be generated from public constants only
     public    const PUBLIC_CONST    = 'public constant';    // this will be an enumerator
@@ -58,9 +56,9 @@ class UserStatus extends Enum
     private   const PRIVATE_CONST   = 'private constant';   // this will NOT be an enumerator
 
     // works since PHP-7.0 - see https://wiki.php.net/rfc/context_sensitive_lexer
-    const TRUE      = true;
-    const FALSE     = false;
-    const NULL      = null;
+    const TRUE      = 'true';
+    const FALSE     = 'false';
+    const NULL      = 'null';
     const PUBLIC    = 'public';
     const PRIVATE   = 'private';
     const PROTECTED = 'protected';
@@ -85,11 +83,11 @@ $status->getName();    // returns the selected constant name
 $status->getOrdinal(); // returns the ordinal number of the selected constant
 
 // basic methods to list defined enumerators
-UserStatus::getEnumerators()  // returns a list of enumerator instances
-UserStatus::getValues()       // returns a list of enumerator values
-UserStatus::getNames()        // returns a list of enumerator names
-UserStatus::getOrdinals()     // returns a list of ordinal numbers
-UserStatus::getConstants()    // returns an associative array of enumerator names to enumerator values
+UserStatus::getEnumerators();  // returns a list of enumerator instances
+UserStatus::getValues();       // returns a list of enumerator values
+UserStatus::getNames();        // returns a list of enumerator names
+UserStatus::getOrdinals();     // returns a list of ordinal numbers
+UserStatus::getConstants();    // returns an associative array of enumerator names to enumerator values
 
 // same enumerators (of the same enumeration class) holds the same instance
 UserStatus::get(UserStatus::ACTIVE) === UserStatus::ACTIVE()
@@ -135,11 +133,12 @@ Because in normal OOP the above example allows `UserStatus` and types inherited 
 Please think about the following example:
 
 ```php
-class ExtendedUserStatus
+class ExtendedUserStatus extends UserStatus
 {
     const EXTENDED = 'extended';
 }
 
+$user = new User();
 $user->setStatus(ExtendedUserStatus::EXTENDED());
 ```
 
@@ -209,10 +208,10 @@ $enumSet->isEqual($other);    // Check if the EnumSet is the same as other
 $enumSet->isSubset($other);   // Check if the EnumSet is a subset of other
 $enumSet->isSuperset($other); // Check if the EnumSet is a superset of other
 
-$enumSet->union($other[, ...]);     // Produce a new set with enumerators from both this and other (this | other)
-$enumSet->intersect($other[, ...]); // Produce a new set with enumerators common to both this and other (this & other)
-$enumSet->diff($other[, ...]);      // Produce a new set with enumerators in this but not in other (this - other)
-$enumSet->symDiff($other[, ...]);   // Produce a new set with enumerators in either this and other but not in both (this ^ (other | other))
+$enumSet->union($other);     // Produce a new set with enumerators from both this and other (this | other)
+$enumSet->intersect($other); // Produce a new set with enumerators common to both this and other (this & other)
+$enumSet->diff($other);      // Produce a new set with enumerators in this but not in other (this - other)
+$enumSet->symDiff($other);   // Produce a new set with enumerators in either this and other but not in both (this ^ other)
 ```
 
 ## EnumMap
@@ -227,20 +226,48 @@ use MabeEnum\EnumMap;
 // create a new EnumMap
 $enumMap = new EnumMap('UserStatus');
 
-// attach entries (by value or by instance)
-$enumMap->attach(UserStatus::INACTIVE, 'inaktiv');
-$enumMap->attach(UserStatus::ACTIVE(), 'aktiv');
-$enumMap->attach(UserStatus::DELETED(), 'gelöscht');
+// read and write key-value-pairs like an array
+$enumMap[UserStatus::INACTIVE] = 'inaktiv';
+$enumMap[UserStatus::ACTIVE]   = 'aktiv';
+$enumMap[UserStatus::DELETED]  = 'gelöscht';
+$enumMap[UserStatus::INACTIVE]; // 'inaktiv';
+$enumMap[UserStatus::ACTIVE];   // 'aktiv';
+$enumMap[UserStatus::DELETED];  // 'gelöscht';
 
-// detach entries (by value or by instance)
-$enumMap->detach(UserStatus::INACTIVE);
-$enumMap->detach(UserStatus::DELETED());
+isset($enumMap[UserStatus::DELETED]); // true
+unset($enumMap[UserStatus::DELETED]);
+isset($enumMap[UserStatus::DELETED]); // false
 
-// iterate
+// ... no matter if you use enumerator values or enumerator objects
+$enumMap[UserStatus::INACTIVE()] = 'inaktiv';
+$enumMap[UserStatus::ACTIVE()]   = 'aktiv';
+$enumMap[UserStatus::DELETED()]  = 'gelöscht';
+$enumMap[UserStatus::INACTIVE()]; // 'inaktiv';
+$enumMap[UserStatus::ACTIVE()];   // 'aktiv';
+$enumMap[UserStatus::DELETED()];  // 'gelöscht';
+
+isset($enumMap[UserStatus::DELETED()]); // true
+unset($enumMap[UserStatus::DELETED()]);
+isset($enumMap[UserStatus::DELETED()]); // false
+
+
+// support for null aware exists check
+$enumMap[UserStatus::NULL] = null;
+isset($enumMap[UserStatus::NULL]);    // false
+$enumMap->contains(UserStatus::NULL); // true
+
+
+// iterating over the map
 foreach ($enumMap as $enum => $value) {
-    var_dump(get_class($enum)); // UserStatus
-    var_dump(gettype($value))   // string
+    get_class($enum);  // UserStatus (enumerator object)
+    gettype($value);   // string (the value the enumerators maps to)
 }
+
+// get a list of keys (= a list of enumerator objects)
+$enumMap->getKeys();
+
+// get a list of values (= a list of values the enumerator maps to)
+$enumMap->getValues();
 ```
 
 ## Serializing

--- a/bench/EnumMapBench.php
+++ b/bench/EnumMapBench.php
@@ -48,9 +48,39 @@ class EnumMapBench
 
         $this->emptyMap = new EnumMap(Enum66::class);
         $this->fullMap  = new EnumMap(Enum66::class);
-        foreach ($this->enumerators as $enumerator) {
-            $this->fullMap->offsetSet($enumerator);
+        foreach ($this->enumerators as $i => $enumerator) {
+            $this->fullMap->offsetSet($enumerator, $i);
         }
+    }
+
+    public function benchGetKeysEmpty()
+    {
+        $this->emptyMap->getKeys();
+    }
+
+    public function benchGetKeysFull()
+    {
+        $this->fullMap->getKeys();
+    }
+
+    public function benchGetValuesEmpty()
+    {
+        $this->emptyMap->getValues();
+    }
+
+    public function benchGetValuesFull()
+    {
+        $this->fullMap->getValues();
+    }
+
+    public function benchSearchTypeJuggling()
+    {
+        $this->fullMap->search('31');
+    }
+
+    public function benchSearchStrict()
+    {
+        $this->fullMap->search(31, true);
     }
 
     public function benchOffsetSetEnumerator()
@@ -81,31 +111,31 @@ class EnumMapBench
         }
     }
 
-    public function benchOffsetExistsEnumeratorTrue()
+    public function benchOffsetExistsEnumerator()
     {
         foreach ($this->enumerators as $enumerator) {
             $this->fullMap->offsetExists($enumerator);
         }
     }
 
-    public function benchOffsetExistsEnumeratorFalse()
+    public function benchOffsetExistsValue()
+    {
+        foreach ($this->values as $value) {
+            $this->fullMap->offsetExists($value);
+        }
+    }
+
+    public function benchContainsEnumerator()
     {
         foreach ($this->enumerators as $enumerator) {
-            $this->fullMap->offsetExists($enumerator);
+            $this->fullMap->contains($enumerator);
         }
     }
 
-    public function benchOffsetExistsValueTrue()
+    public function benchContainsValue()
     {
         foreach ($this->values as $value) {
-            $this->fullMap->offsetExists($value);
-        }
-    }
-
-    public function benchOffsetExistsValueFalse()
-    {
-        foreach ($this->values as $value) {
-            $this->fullMap->offsetExists($value);
+            $this->fullMap->contains($value);
         }
     }
 

--- a/bench/EnumMapBench.php
+++ b/bench/EnumMapBench.php
@@ -48,8 +48,8 @@ class EnumMapBench
 
         $this->emptyMap = new EnumMap(Enum66::class);
         $this->fullMap  = new EnumMap(Enum66::class);
-        foreach ($this->enumerators as $i => $enumerator) {
-            $this->fullMap->offsetSet($enumerator, $i);
+        foreach ($this->enumerators as $enumerator) {
+            $this->fullMap->offsetSet($enumerator);
         }
     }
 

--- a/composer.json
+++ b/composer.json
@@ -24,9 +24,6 @@
         "php":            ">=5.6",
         "ext-reflection": "*"
     },
-    "suggest": {
-        "php": "PHP>=5.4 will be required for using trait EnumSerializableTrait"
-    },
     "require-dev": {
         "phpunit/phpunit": "^5.7 || ^6.0",
         "phpbench/phpbench": "@dev",

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -247,7 +247,7 @@ abstract class Enum
         }
 
         if (!isset(self::$names[$class][$ordinal])) {
-            throw new InvalidArgumentException(sprintf(
+            throw new InvalidArgumentException(\sprintf(
                 'Invalid ordinal number, must between 0 and %s',
                 \count(self::$names[$class]) - 1
             ));

--- a/src/EnumMap.php
+++ b/src/EnumMap.php
@@ -148,7 +148,7 @@ class EnumMap implements ArrayAccess, Countable, SeekableIterator
     {
         $enumeration = $this->enumeration;
         $ord = $enumeration::get($enumerator)->getOrdinal();
-        if (!isset($this->map[$ord])) {
+        if (!isset($this->map[$ord]) && !array_key_exists($ord, $this->map)) {
             throw new UnexpectedValueException(\sprintf(
                 "Enumerator '%s' could not be found",
                 \is_object($enumerator) ? $enumerator->getValue() : $enumerator
@@ -161,7 +161,7 @@ class EnumMap implements ArrayAccess, Countable, SeekableIterator
     /**
      * Attach a new enumerator or overwrite an existing one
      * @param Enum|null|boolean|int|float|string $enumerator
-     * @param mixed                              $data
+     * @param mixed                              $value
      * @return void
      * @throws InvalidArgumentException On an invalid given enumerator
      * @see attach()

--- a/src/EnumMap.php
+++ b/src/EnumMap.php
@@ -171,7 +171,7 @@ class EnumMap implements ArrayAccess, Countable, SeekableIterator
         $enumeration = $this->enumeration;
         $ord = $enumeration::get($enumerator)->getOrdinal();
 
-        if (!isset($this->map[$ord])) {
+        if (!array_key_exists($ord, $this->map)) {
             $this->ordinals[] = $ord;
         }
         $this->map[$ord] = $value;

--- a/src/EnumSet.php
+++ b/src/EnumSet.php
@@ -232,7 +232,7 @@ class EnumSet implements Iterator, Countable
     }
 
     /**
-     * Test if the iterator in a valid state
+     * Test if the iterator is in a valid state
      * @return boolean
      */
     public function valid()
@@ -377,7 +377,7 @@ class EnumSet implements Iterator, Countable
     public function union(EnumSet $other)
     {
         if ($this->enumeration !== $other->enumeration) {
-            throw new InvalidArgumentException(sprintf(
+            throw new InvalidArgumentException(\sprintf(
                 'Other should be of the same enumeration as this %s',
                 $this->enumeration
             ));
@@ -397,7 +397,7 @@ class EnumSet implements Iterator, Countable
     public function intersect(EnumSet $other)
     {
         if ($this->enumeration !== $other->enumeration) {
-            throw new InvalidArgumentException(sprintf(
+            throw new InvalidArgumentException(\sprintf(
                 'Other should be of the same enumeration as this %s',
                 $this->enumeration
             ));
@@ -417,7 +417,7 @@ class EnumSet implements Iterator, Countable
     public function diff(EnumSet $other)
     {
         if ($this->enumeration !== $other->enumeration) {
-            throw new InvalidArgumentException(sprintf(
+            throw new InvalidArgumentException(\sprintf(
                 'Other should be of the same enumeration as this %s',
                 $this->enumeration
             ));
@@ -437,7 +437,7 @@ class EnumSet implements Iterator, Countable
     public function symDiff(EnumSet $other)
     {
         if ($this->enumeration !== $other->enumeration) {
-            throw new InvalidArgumentException(sprintf(
+            throw new InvalidArgumentException(\sprintf(
                 'Other should be of the same enumeration as this %s',
                 $this->enumeration
             ));

--- a/tests/MabeEnumTest/EnumMapTest.php
+++ b/tests/MabeEnumTest/EnumMapTest.php
@@ -8,6 +8,7 @@ use MabeEnumTest\TestAsset\EnumBasic;
 use MabeEnumTest\TestAsset\EnumInheritance;
 use OutOfBoundsException;
 use PHPUnit\Framework\TestCase;
+use UnexpectedValueException;
 
 /**
  * Unit tests for the class MabeEnum\EnumMap
@@ -98,6 +99,14 @@ class EnumMapTest extends TestCase
         $this->assertSame([], $enumMap->getValues());
     }
 
+    public function testOffsetGetMissingKey()
+    {
+        $enumMap = new EnumMap(EnumBasic::class);
+
+        $this->expectException(UnexpectedValueException::class);
+        $enumMap->offsetGet(EnumBasic::ONE);
+    }
+
     public function testIterate()
     {
         $enumMap = new EnumMap(EnumBasic::class);
@@ -132,6 +141,7 @@ class EnumMapTest extends TestCase
 
         // go to the next element (out of range)
         $this->assertNull($enumMap->next());
+        $this->assertNull($enumMap->current());
         $this->assertFalse($enumMap->valid());
         $this->assertSame(null, $enumMap->key());
 
@@ -243,6 +253,8 @@ class EnumMapTest extends TestCase
         $enumMap[EnumBasic::ONE()] = null;
 
         $this->assertSame(1, $enumMap->count());
+        $this->assertNull($enumMap[EnumBasic::ONE]);
+        $this->assertNull($enumMap->offsetGet(EnumBasic::ONE));
         $this->assertSame([EnumBasic::ONE()], $enumMap->getKeys());
 
         $enumMap->rewind();

--- a/tests/MabeEnumTest/EnumMapTest.php
+++ b/tests/MabeEnumTest/EnumMapTest.php
@@ -19,28 +19,26 @@ use Serializable;
  */
 class EnumMapTest extends TestCase
 {
-    public function testBasic()
+    public function testBasicWithEnumeratorInstances()
     {
         $enumMap = new EnumMap(EnumBasic::class);
         $this->assertSame(EnumBasic::class, $enumMap->getEnumeration());
 
-        $enum1  = EnumBasic::ONE();
+        $enum1  = EnumBasic::TWO();
         $value1 = 'value1';
 
-        $enum2  = EnumBasic::TWO();
+        $enum2  = EnumBasic::ONE();
         $value2 = 'value2';
 
         $this->assertFalse($enumMap->contains($enum1));
         $this->assertNull($enumMap->attach($enum1, $value1));
         $this->assertTrue($enumMap->contains($enum1));
         $this->assertSame($value1, $enumMap[$enum1]);
-        $this->assertSame(spl_object_hash($enum1), $enumMap->getHash($enum1));
 
         $this->assertFalse($enumMap->contains($enum2));
         $this->assertNull($enumMap->attach($enum2, $value2));
         $this->assertTrue($enumMap->contains($enum2));
         $this->assertSame($value2, $enumMap[$enum2]);
-        $this->assertSame(spl_object_hash($enum2), $enumMap->getHash($enum2));
 
         $this->assertNull($enumMap->detach($enum1));
         $this->assertFalse($enumMap->contains($enum1));
@@ -49,7 +47,7 @@ class EnumMapTest extends TestCase
         $this->assertFalse($enumMap->contains($enum2));
     }
 
-    public function testBasicWithConstantValuesAsEnums()
+    public function testBasicWithEnumeratorValues()
     {
         $enumMap = new EnumMap(EnumBasic::class);
 
@@ -186,9 +184,13 @@ class EnumMapTest extends TestCase
     public function testSerializable()
     {
         $enumMap = new EnumMap(EnumBasic::class);
-        if ($enumMap instanceof Serializable) {
-            $enumMap->offsetSet(EnumBasic::ONE, 'one');
-            serialize($enumMap);
-        }
+        $enumMap[EnumBasic::ONE()] = 'one';
+
+        $enumMapCopy = unserialize(serialize($enumMap));
+        $this->assertTrue($enumMapCopy->offsetExists(EnumBasic::ONE));
+        $this->assertFalse($enumMapCopy->offsetExists(EnumBasic::TWO));
+
+        // unserialized instance should be the same
+        $this->assertSame(EnumBasic::ONE(), $enumMapCopy->key());
     }
 }

--- a/tests/MabeEnumTest/EnumMapTest.php
+++ b/tests/MabeEnumTest/EnumMapTest.php
@@ -242,6 +242,9 @@ class EnumMapTest extends TestCase
         $enumMap = new EnumMap(EnumBasic::class);
         $enumMap[EnumBasic::ONE()] = null;
 
+        $this->assertSame(1, $enumMap->count());
+        $this->assertSame([EnumBasic::ONE()], $enumMap->getKeys());
+
         $enumMap->rewind();
         $this->assertSame(1, $enumMap->count());
         $this->assertTrue($enumMap->valid());
@@ -252,7 +255,28 @@ class EnumMapTest extends TestCase
         $this->assertFalse(isset($enumMap[EnumBasic::ONE()]));
         $this->assertFalse($enumMap->offsetExists(EnumBasic::ONE));
         $this->assertFalse($enumMap->offsetExists(EnumBasic::ONE()));
+        $this->assertTrue($enumMap->contains(EnumBasic::ONE));
+        $this->assertTrue($enumMap->contains(EnumBasic::ONE()));
 
+        // add the same enumeration a second time should do nothing
+        $enumMap->offsetSet(EnumBasic::ONE(), null);
+        $this->assertSame(1, $enumMap->count());
+        $this->assertSame([EnumBasic::ONE()], $enumMap->getKeys());
+
+        // overwrite by non null value
+        $enumMap->offsetSet(EnumBasic::ONE(), false);
+        $this->assertSame(1, $enumMap->count());
+        $this->assertSame([EnumBasic::ONE()], $enumMap->getKeys());
+
+        $this->assertSame(1, $enumMap->count());
+        $this->assertTrue($enumMap->valid());
+        $this->assertSame(EnumBasic::ONE(), $enumMap->key());
+        $this->assertFalse($enumMap->current());
+
+        $this->assertTrue(isset($enumMap[EnumBasic::ONE]));
+        $this->assertTrue(isset($enumMap[EnumBasic::ONE()]));
+        $this->assertTrue($enumMap->offsetExists(EnumBasic::ONE));
+        $this->assertTrue($enumMap->offsetExists(EnumBasic::ONE()));
         $this->assertTrue($enumMap->contains(EnumBasic::ONE));
         $this->assertTrue($enumMap->contains(EnumBasic::ONE()));
     }


### PR DESCRIPTION
* if data are serializable the `EnumMap` is serializable, too
* no longer based on `SplObjectStorage`
* no longer implement `Serializable`
* still implements `ArrayAccess`, `Countable` and `Iterator`
* new implements `SeekableIterator`
* Methods removed:
  * `public function attach($enumerator) : void`
    * please use `public function offsetSet($enumerator) : void`
  * `public function detach($enumerator): void`
    * please use `public function offsetUnset($enumerator) : void`
  * `public addAll(SplObjectStorage $storage) : void`
  * `public getHash(object $object) : string`
  * `public removeAll(SplObjectStorage $storage) : void`
  * `public removeAllExcept(SplObjectStorage $storage) : void`
  * `public serialize(void) : string`
  * `public setInfo(mixed $data) : void`
  * `public unserialize(string $serialized) : void`
* Methods changed:
  * `public contains($enumerator) : bool`
    * same as `public offsetExists($enumerator) : bool` but returns true on `NULL` values
* Methods added:
  * `public function seek(int $pos) : void`
  * `public function getKeys() : Enum[]`
  * `public function getValues() : mixed[]`
  * `public function search($enumerator, bool $strict) : Enum|null`

fixes #91