### PR TITLE
use of generators

### DIFF
--- a/src/EnumMap.php
+++ b/src/EnumMap.php
@@ -73,7 +73,10 @@ class EnumMap implements ArrayAccess, Countable, SeekableIterator
      */
     public function getKeys()
     {
-        return \array_map([$this->enumeration, 'byOrdinal'], $this->ordinals);
+        $enumeration = $this->enumeration;
+        foreach ($this->ordinals as $ord) {
+            yield $enumeration::byOrdinal($ord);
+        }
     }
 
     /**
@@ -82,7 +85,9 @@ class EnumMap implements ArrayAccess, Countable, SeekableIterator
      */
     public function getValues()
     {
-        return \array_values($this->map);
+        foreach ($this->map as $value) {
+            yield $value;
+        }
     }
 
     /**

--- a/src/EnumSet.php
+++ b/src/EnumSet.php
@@ -468,9 +468,8 @@ class EnumSet implements Iterator, Countable
      */
     private function doGetOrdinalsBin()
     {
-        $ordinals = [];
-        $bitset   = $this->bitset;
-        $byteLen  = \strlen($bitset);
+        $bitset  = $this->bitset;
+        $byteLen = \strlen($bitset);
         for ($bytePos = 0; $bytePos < $byteLen; ++$bytePos) {
             if ($bitset[$bytePos] === "\0") {
                 // fast skip null byte
@@ -480,11 +479,10 @@ class EnumSet implements Iterator, Countable
             $ord = \ord($bitset[$bytePos]);
             for ($bitPos = 0; $bitPos < 8; ++$bitPos) {
                 if ($ord & (1 << $bitPos)) {
-                    $ordinals[] = $bytePos * 8 + $bitPos;
+                    yield $bytePos * 8 + $bitPos;
                 }
             }
         }
-        return $ordinals;
     }
 
     /**
@@ -498,15 +496,13 @@ class EnumSet implements Iterator, Countable
      */
     private function doGetOrdinalsInt()
     {
-        $ordinals   = [];
         $ordinalMax = $this->ordinalMax;
         $bitset     = $this->bitset;
         for ($ord = 0; $ord < $ordinalMax; ++$ord) {
             if ($bitset & (1 << $ord)) {
-                $ordinals[] = $ord;
+                yield $ord;
             }
         }
-        return $ordinals;
     }
 
     /**
@@ -516,11 +512,9 @@ class EnumSet implements Iterator, Countable
     public function getValues()
     {
         $enumeration = $this->enumeration;
-        $values      = [];
         foreach ($this->getOrdinals() as $ord) {
-            $values[] = $enumeration::byOrdinal($ord)->getValue();
+            yield $enumeration::byOrdinal($ord)->getValue();
         }
-        return $values;
     }
 
     /**
@@ -530,11 +524,9 @@ class EnumSet implements Iterator, Countable
     public function getNames()
     {
         $enumeration = $this->enumeration;
-        $names       = [];
         foreach ($this->getOrdinals() as $ord) {
-            $names[] = $enumeration::byOrdinal($ord)->getName();
+            yield $enumeration::byOrdinal($ord)->getName();
         }
-        return $names;
     }
 
     /**
@@ -544,11 +536,9 @@ class EnumSet implements Iterator, Countable
     public function getEnumerators()
     {
         $enumeration = $this->enumeration;
-        $enumerators = [];
         foreach ($this->getOrdinals() as $ord) {
-            $enumerators[] = $enumeration::byOrdinal($ord);
+            yield $enumeration::byOrdinal($ord);
         }
-        return $enumerators;
     }
 
     /**

--- a/tests/MabeEnumTest/EnumMapTest.php
+++ b/tests/MabeEnumTest/EnumMapTest.php
@@ -32,32 +32,32 @@ class EnumMapTest extends TestCase
 
         $this->assertFalse($enumMap->contains($enum1));
         $this->assertFalse($enumMap->contains($enum2));
-        $this->assertSame([], $enumMap->getKeys());
-        $this->assertSame([], $enumMap->getValues());
+        $this->assertSame([], iterator_to_array($enumMap->getKeys()));
+        $this->assertSame([], iterator_to_array($enumMap->getValues()));
 
         $this->assertNull($enumMap->offsetSet($enum1, $value1));
         $this->assertTrue($enumMap->contains($enum1));
         $this->assertSame($value1, $enumMap[$enum1]);
         $this->assertFalse($enumMap->contains($enum2));
-        $this->assertSame([$enum1], $enumMap->getKeys());
-        $this->assertSame([$value1], $enumMap->getValues());
+        $this->assertSame([$enum1], iterator_to_array($enumMap->getKeys()));
+        $this->assertSame([$value1], iterator_to_array($enumMap->getValues()));
 
 
         $this->assertNull($enumMap->offsetSet($enum2, $value2));
         $this->assertTrue($enumMap->contains($enum2));
         $this->assertSame($value2, $enumMap[$enum2]);
-        $this->assertSame([$enum1, $enum2], $enumMap->getKeys());
-        $this->assertSame([$value1, $value2], $enumMap->getValues());
+        $this->assertSame([$enum1, $enum2], iterator_to_array($enumMap->getKeys()));
+        $this->assertSame([$value1, $value2], iterator_to_array($enumMap->getValues()));
 
         $this->assertNull($enumMap->offsetUnset($enum1));
         $this->assertFalse($enumMap->contains($enum1));
-        $this->assertSame([$enum2], $enumMap->getKeys());
-        $this->assertSame([$value2], $enumMap->getValues());
+        $this->assertSame([$enum2], iterator_to_array($enumMap->getKeys()));
+        $this->assertSame([$value2], iterator_to_array($enumMap->getValues()));
 
         $this->assertNull($enumMap->offsetUnset($enum2));
         $this->assertFalse($enumMap->contains($enum2));
-        $this->assertSame([], $enumMap->getKeys());
-        $this->assertSame([], $enumMap->getValues());
+        $this->assertSame([], iterator_to_array($enumMap->getKeys()));
+        $this->assertSame([], iterator_to_array($enumMap->getValues()));
     }
 
     public function testBasicWithEnumeratorValues()
@@ -72,31 +72,34 @@ class EnumMapTest extends TestCase
 
         $this->assertFalse($enumMap->contains($enum1));
         $this->assertFalse($enumMap->contains($enum2));
-        $this->assertSame([], $enumMap->getKeys());
-        $this->assertSame([], $enumMap->getValues());
+        $this->assertSame([], iterator_to_array($enumMap->getKeys()));
+        $this->assertSame([], iterator_to_array($enumMap->getValues()));
 
         $this->assertNull($enumMap->offsetSet($enum1, $value1));
         $this->assertTrue($enumMap->contains($enum1));
         $this->assertSame($value1, $enumMap[$enum1]);
         $this->assertFalse($enumMap->contains($enum2));
-        $this->assertSame([EnumBasic::byValue($enum1)], $enumMap->getKeys());
-        $this->assertSame([$value1], $enumMap->getValues());
+        $this->assertSame([EnumBasic::byValue($enum1)], iterator_to_array($enumMap->getKeys()));
+        $this->assertSame([$value1], iterator_to_array($enumMap->getValues()));
 
         $this->assertNull($enumMap->offsetSet($enum2, $value2));
         $this->assertTrue($enumMap->contains($enum2));
         $this->assertSame($value2, $enumMap[$enum2]);
-        $this->assertSame([EnumBasic::byValue($enum1), EnumBasic::byValue($enum2)], $enumMap->getKeys());
-        $this->assertSame([$value1, $value2], $enumMap->getValues());
+        $this->assertSame(
+            [EnumBasic::byValue($enum1), EnumBasic::byValue($enum2)],
+            iterator_to_array($enumMap->getKeys())
+        );
+        $this->assertSame([$value1, $value2], iterator_to_array($enumMap->getValues()));
 
         $this->assertNull($enumMap->offsetUnset($enum1));
         $this->assertFalse($enumMap->contains($enum1));
-        $this->assertSame([EnumBasic::byValue($enum2)], $enumMap->getKeys());
-        $this->assertSame([$value2], $enumMap->getValues());
+        $this->assertSame([EnumBasic::byValue($enum2)], iterator_to_array($enumMap->getKeys()));
+        $this->assertSame([$value2], iterator_to_array($enumMap->getValues()));
 
         $this->assertNull($enumMap->offsetUnset($enum2));
         $this->assertFalse($enumMap->contains($enum2));
-        $this->assertSame([], $enumMap->getKeys());
-        $this->assertSame([], $enumMap->getValues());
+        $this->assertSame([], iterator_to_array($enumMap->getKeys()));
+        $this->assertSame([], iterator_to_array($enumMap->getValues()));
     }
 
     public function testOffsetGetMissingKey()
@@ -255,7 +258,7 @@ class EnumMapTest extends TestCase
         $this->assertSame(1, $enumMap->count());
         $this->assertNull($enumMap[EnumBasic::ONE]);
         $this->assertNull($enumMap->offsetGet(EnumBasic::ONE));
-        $this->assertSame([EnumBasic::ONE()], $enumMap->getKeys());
+        $this->assertSame([EnumBasic::ONE()], iterator_to_array($enumMap->getKeys()));
 
         $enumMap->rewind();
         $this->assertSame(1, $enumMap->count());
@@ -273,12 +276,12 @@ class EnumMapTest extends TestCase
         // add the same enumeration a second time should do nothing
         $enumMap->offsetSet(EnumBasic::ONE(), null);
         $this->assertSame(1, $enumMap->count());
-        $this->assertSame([EnumBasic::ONE()], $enumMap->getKeys());
+        $this->assertSame([EnumBasic::ONE()], iterator_to_array($enumMap->getKeys()));
 
         // overwrite by non null value
         $enumMap->offsetSet(EnumBasic::ONE(), false);
         $this->assertSame(1, $enumMap->count());
-        $this->assertSame([EnumBasic::ONE()], $enumMap->getKeys());
+        $this->assertSame([EnumBasic::ONE()], iterator_to_array($enumMap->getKeys()));
 
         $this->assertSame(1, $enumMap->count());
         $this->assertTrue($enumMap->valid());

--- a/tests/MabeEnumTest/EnumSetTest.php
+++ b/tests/MabeEnumTest/EnumSetTest.php
@@ -668,25 +668,25 @@ class EnumSetTest extends TestCase
     public function testGetOrdinalsInt()
     {
         $set = new EnumSet(EnumBasic::class);
-        $this->assertSame([], $set->getOrdinals());
+        $this->assertSame([], iterator_to_array($set->getOrdinals()));
 
         foreach (EnumBasic::getConstants() as $value) {
             $set->attach($value);
         }
 
-        $this->assertSame(range(0, count(EnumBasic::getConstants()) - 1), $set->getOrdinals());
+        $this->assertSame(range(0, count(EnumBasic::getConstants()) - 1), iterator_to_array($set->getOrdinals()));
     }
 
     public function testGetOrdinalsBin()
     {
         $set = new EnumSet(Enum66::class);
-        $this->assertSame([], $set->getOrdinals());
+        $this->assertSame([], iterator_to_array($set->getOrdinals()));
 
         foreach (Enum66::getConstants() as $value) {
             $set->attach($value);
         }
 
-        $this->assertSame(range(0, count(Enum66::getConstants()) - 1), $set->getOrdinals());
+        $this->assertSame(range(0, count(Enum66::getConstants()) - 1), iterator_to_array($set->getOrdinals()));
     }
 
     public function testGetOrdinalsIntDoesNotEffectIteratorPosition()
@@ -714,13 +714,13 @@ class EnumSetTest extends TestCase
     public function testGetEnumerators()
     {
         $set = new EnumSet(EnumBasic::class);
-        $this->assertSame([], $set->getEnumerators());
+        $this->assertSame([], iterator_to_array($set->getEnumerators()));
 
         foreach (EnumBasic::getConstants() as $value) {
             $set->attach($value);
         }
 
-        $this->assertSame(EnumBasic::getEnumerators(), $set->getEnumerators());
+        $this->assertSame(EnumBasic::getEnumerators(), iterator_to_array($set->getEnumerators()));
     }
 
     public function testGetEnumeratorsDoesNotEffectIteratorPosition()
@@ -737,13 +737,13 @@ class EnumSetTest extends TestCase
     public function testGetValues()
     {
         $set = new EnumSet(EnumBasic::class);
-        $this->assertSame([], $set->getValues());
+        $this->assertSame([], iterator_to_array($set->getValues()));
 
         foreach (EnumBasic::getConstants() as $value) {
             $set->attach($value);
         }
 
-        $this->assertSame(array_values(EnumBasic::getConstants()), $set->getValues());
+        $this->assertSame(array_values(EnumBasic::getConstants()), iterator_to_array($set->getValues()));
     }
 
     public function testGetValuesDoesNotEffectIteratorPosition()
@@ -760,13 +760,13 @@ class EnumSetTest extends TestCase
     public function testGetNames()
     {
         $set = new EnumSet(EnumBasic::class);
-        $this->assertSame([], $set->getNames());
+        $this->assertSame([], iterator_to_array($set->getNames()));
 
         foreach (EnumBasic::getConstants() as $value) {
             $set->attach($value);
         }
 
-        $this->assertSame(array_keys(EnumBasic::getConstants()), $set->getNames());
+        $this->assertSame(array_keys(EnumBasic::getConstants()), iterator_to_array($set->getNames()));
     }
 
     public function testGetNamesDoesNotEffectIteratorPosition()
@@ -797,7 +797,7 @@ class EnumSetTest extends TestCase
             EnumBasic::TWO,
             EnumBasic::THREE,
             EnumBasic::FOUR,
-        ], $rs->getValues());
+        ], iterator_to_array($rs->getValues()));
     }
 
     public function testUnionThrowsInvalidArgumentException()
@@ -822,7 +822,7 @@ class EnumSetTest extends TestCase
         $set2->attach(EnumBasic::FOUR);
 
         $rs = $set1->intersect($set2);
-        $this->assertSame([EnumBasic::TWO, EnumBasic::THREE], $rs->getValues());
+        $this->assertSame([EnumBasic::TWO, EnumBasic::THREE], iterator_to_array($rs->getValues()));
     }
 
     public function testIntersectThrowsInvalidArgumentException()
@@ -847,7 +847,7 @@ class EnumSetTest extends TestCase
         $set2->attach(EnumBasic::FOUR);
 
         $rs = $set1->diff($set2);
-        $this->assertSame([EnumBasic::ONE], $rs->getValues());
+        $this->assertSame([EnumBasic::ONE], iterator_to_array($rs->getValues()));
     }
 
     public function testDiffThrowsInvalidArgumentException()
@@ -875,7 +875,7 @@ class EnumSetTest extends TestCase
         $this->assertSame([
             EnumBasic::ONE,
             EnumBasic::FOUR,
-        ], $rs->getValues());
+        ], iterator_to_array($rs->getValues()));
     }
 
     public function testSymDiffThrowsInvalidArgumentException()


### PR DESCRIPTION
@prolic please can you have a look - I just tested if it makes sense to use generators but this performance speed-up must be wrong but all tests passed:

```
benchmark: EnumBench, subject: benchGetEnumerators
+--------+--------+------+------------------------+----------------------------+
| groups | params | revs | vcs_branch:master:mean | vcs_branch:generators:mean |
+--------+--------+------+------------------------+----------------------------+
|        | []     | 2500 | 11.202μs               | 11.211μs                   |
+--------+--------+------+------------------------+----------------------------+

benchmark: EnumSet32Bench, subject: benchGetEnumerators
+--------+--------+------+------------------------+----------------------------+
| groups | params | revs | vcs_branch:master:mean | vcs_branch:generators:mean |
+--------+--------+------+------------------------+----------------------------+
|        | []     | 2000 | 15.575μs               | 0.059μs                    |
+--------+--------+------+------------------------+----------------------------+

benchmark: EnumSet66Bench, subject: benchGetEnumerators
+--------+--------+------+------------------------+----------------------------+
| groups | params | revs | vcs_branch:master:mean | vcs_branch:generators:mean |
+--------+--------+------+------------------------+----------------------------+
|        | []     | 2000 | 33.223μs               | 0.059μs                    |
+--------+--------+------+------------------------+----------------------------+

benchmark: EnumMapBench, subject: benchGetKeysEmpty
+--------+--------+------+------------------------+----------------------------+
| groups | params | revs | vcs_branch:master:mean | vcs_branch:generators:mean |
+--------+--------+------+------------------------+----------------------------+
|        | []     | 2000 | 0.420μs                | 0.059μs                    |
+--------+--------+------+------------------------+----------------------------+

benchmark: EnumMapBench, subject: benchGetKeysFull
+--------+--------+------+------------------------+----------------------------+
| groups | params | revs | vcs_branch:master:mean | vcs_branch:generators:mean |
+--------+--------+------+------------------------+----------------------------+
|        | []     | 2000 | 22.028μs               | 0.060μs                    |
+--------+--------+------+------------------------+----------------------------+

benchmark: EnumBench, subject: benchGetNames
+--------+--------+------+------------------------+----------------------------+
| groups | params | revs | vcs_branch:master:mean | vcs_branch:generators:mean |
+--------+--------+------+------------------------+----------------------------+
|        | []     | 2500 | 0.156μs                | 0.156μs                    |
+--------+--------+------+------------------------+----------------------------+

benchmark: EnumSet32Bench, subject: benchGetNames
+--------+--------+------+------------------------+----------------------------+
| groups | params | revs | vcs_branch:master:mean | vcs_branch:generators:mean |
+--------+--------+------+------------------------+----------------------------+
|        | []     | 2000 | 19.462μs               | 0.059μs                    |
+--------+--------+------+------------------------+----------------------------+

benchmark: EnumSet66Bench, subject: benchGetNames
+--------+--------+------+------------------------+----------------------------+
| groups | params | revs | vcs_branch:master:mean | vcs_branch:generators:mean |
+--------+--------+------+------------------------+----------------------------+
|        | []     | 2000 | 40.846μs               | 0.059μs                    |
+--------+--------+------+------------------------+----------------------------+

benchmark: EnumBench, subject: benchGetOrdinals
+--------+--------+------+------------------------+----------------------------+
| groups | params | revs | vcs_branch:master:mean | vcs_branch:generators:mean |
+--------+--------+------+------------------------+----------------------------+
|        | []     | 2500 | 0.519μs                | 0.505μs                    |
+--------+--------+------+------------------------+----------------------------+

benchmark: EnumSet32Bench, subject: benchGetOrdinalsEmpty
+--------+--------+------+------------------------+----------------------------+
| groups | params | revs | vcs_branch:master:mean | vcs_branch:generators:mean |
+--------+--------+------+------------------------+----------------------------+
|        | []     | 2000 | 1.114μs                | 0.295μs                    |
+--------+--------+------+------------------------+----------------------------+

benchmark: EnumSet66Bench, subject: benchGetOrdinalsEmpty
+--------+--------+------+------------------------+----------------------------+
| groups | params | revs | vcs_branch:master:mean | vcs_branch:generators:mean |
+--------+--------+------+------------------------+----------------------------+
|        | []     | 2000 | 0.548μs                | 0.279μs                    |
+--------+--------+------+------------------------+----------------------------+

benchmark: EnumSet32Bench, subject: benchGetOrdinalsFull
+--------+--------+------+------------------------+----------------------------+
| groups | params | revs | vcs_branch:master:mean | vcs_branch:generators:mean |
+--------+--------+------+------------------------+----------------------------+
|        | []     | 2000 | 1.645μs                | 0.295μs                    |
+--------+--------+------+------------------------+----------------------------+

benchmark: EnumSet66Bench, subject: benchGetOrdinalsFull
+--------+--------+------+------------------------+----------------------------+
| groups | params | revs | vcs_branch:master:mean | vcs_branch:generators:mean |
+--------+--------+------+------------------------+----------------------------+
|        | []     | 2000 | 4.801μs                | 0.278μs                    |
+--------+--------+------+------------------------+----------------------------+

benchmark: EnumBench, subject: benchGetValues
+--------+--------+------+------------------------+----------------------------+
| groups | params | revs | vcs_branch:master:mean | vcs_branch:generators:mean |
+--------+--------+------+------------------------+----------------------------+
|        | []     | 2500 | 0.428μs                | 0.428μs                    |
+--------+--------+------+------------------------+----------------------------+

benchmark: EnumSet32Bench, subject: benchGetValues
+--------+--------+------+------------------------+----------------------------+
| groups | params | revs | vcs_branch:master:mean | vcs_branch:generators:mean |
+--------+--------+------+------------------------+----------------------------+
|        | []     | 2000 | 16.630μs               | 0.059μs                    |
+--------+--------+------+------------------------+----------------------------+

benchmark: EnumSet66Bench, subject: benchGetValues
+--------+--------+------+------------------------+----------------------------+
| groups | params | revs | vcs_branch:master:mean | vcs_branch:generators:mean |
+--------+--------+------+------------------------+----------------------------+
|        | []     | 2000 | 35.573μs               | 0.059μs                    |
+--------+--------+------+------------------------+----------------------------+

benchmark: EnumMapBench, subject: benchGetValuesEmpty
+--------+--------+------+------------------------+----------------------------+
| groups | params | revs | vcs_branch:master:mean | vcs_branch:generators:mean |
+--------+--------+------+------------------------+----------------------------+
|        | []     | 2000 | 0.128μs                | 0.059μs                    |
+--------+--------+------+------------------------+----------------------------+

benchmark: EnumMapBench, subject: benchGetValuesFull
+--------+--------+------+------------------------+----------------------------+
| groups | params | revs | vcs_branch:master:mean | vcs_branch:generators:mean |
+--------+--------+------+------------------------+----------------------------+
|        | []     | 2000 | 0.328μs                | 0.060μs                    |
+--------+--------+------+------------------------+----------------------------+
```