### PR TITLE
HHVM >3.18.4 & >3.20.2 reports as PHP-7.1 but does not support constant visibility

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -351,9 +351,11 @@ abstract class Enum
 
             do {
                 $scopeConstants = [];
-                if (\PHP_VERSION_ID >= 70100) {
+                if (\PHP_VERSION_ID >= 70100 && method_exists(ReflectionClass::class, 'getReflectionConstants')) {
                     // Since PHP-7.1 visibility modifiers are allowed for class constants
                     // for enumerations we are only interested in public once.
+                    // NOTE: HHVM > 3.26.2 still does not support private/protected constants.
+                    //       It allows the visibility keyword but ignores it.
                     foreach ($reflection->getReflectionConstants() as $reflConstant) {
                         if ($reflConstant->isPublic()) {
                             $scopeConstants[ $reflConstant->getName() ] = $reflConstant->getValue();

--- a/tests/MabeEnumTest/EnumTest.php
+++ b/tests/MabeEnumTest/EnumTest.php
@@ -388,6 +388,9 @@ class EnumTest extends TestCase
         if (PHP_VERSION_ID < 70100) {
             $this->markTestSkipped('This test is for PHP-7.1 and upper only');
         }
+        if (defined('HHVM_VERSION')) {
+            $this->markTestSkipped('HHVM does not support constant visibility');
+        }
 
         $constants = ConstVisibilityEnum::getConstants();
         $this->assertSame(array(
@@ -400,6 +403,9 @@ class EnumTest extends TestCase
     {
         if (PHP_VERSION_ID < 70100) {
             $this->markTestSkipped('This test is for PHP-7.1 and upper only');
+        }
+        if (defined('HHVM_VERSION')) {
+            $this->markTestSkipped('HHVM does not support constant visibility');
         }
 
         $constants = ConstVisibilityEnumExtended::getConstants();


### PR DESCRIPTION
It allows the visibility keyword but ignores it.