### PR TITLE
[WIP]  EnumSet implements IteratorAggregate instead of Iterator 

### DIFF
--- a/src/EnumSet.php
+++ b/src/EnumSet.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace MabeEnum;
 
 use Countable;
-use Iterator;
 use InvalidArgumentException;
+use Iterator;
+use IteratorAggregate;
+use OutOfBoundsException;
 
 /**
  * A set of enumerators of the given enumeration (EnumSet<T>)
@@ -16,7 +18,7 @@ use InvalidArgumentException;
  * @license http://github.com/marc-mabe/php-enum/blob/master/LICENSE.txt New BSD License
  * @link http://github.com/marc-mabe/php-enum for the canonical source repository
  */
-class EnumSet implements Iterator, Countable
+class EnumSet implements IteratorAggregate, Countable
 {
     /**
      * The classname of the Enumeration
@@ -25,16 +27,10 @@ class EnumSet implements Iterator, Countable
     private $enumeration;
 
     /**
-     * Ordinal number of current iterator position
+     * Number of enumerators defined in the enumeration
      * @var int
      */
-    private $ordinal = 0;
-
-    /**
-     * Highest possible ordinal number
-     * @var int
-     */
-    private $ordinalMax;
+    private $enumerationCount;
 
     /**
      * Integer or binary (little endian) bitset
@@ -49,7 +45,6 @@ class EnumSet implements Iterator, Countable
      * 
      * @var string
      */
-    private $fnDoRewind            = 'doRewindInt';
     private $fnDoCount             = 'doCountInt';
     private $fnDoGetOrdinals       = 'doGetOrdinalsInt';
     private $fnDoGetBit            = 'doGetBitInt';
@@ -75,18 +70,17 @@ class EnumSet implements Iterator, Countable
             ));
         }
 
-        $this->enumeration = $enumeration;
-        $this->ordinalMax  = \count($enumeration::getConstants());
+        $this->enumeration      = $enumeration;
+        $this->enumerationCount = \count($enumeration::getConstants());
 
         // By default the bitset is initialized as integer bitset
         // in case the enumeraton has more enumerators then integer bits
         // we will switch this into a binary bitset
-        if ($this->ordinalMax > \PHP_INT_SIZE * 8) {
+        if ($this->enumerationCount > \PHP_INT_SIZE * 8) {
             // init binary bitset with zeros
-            $this->bitset = \str_repeat("\0", (int)\ceil($this->ordinalMax / 8));
+            $this->bitset = \str_repeat("\0", (int)\ceil($this->enumerationCount / 8));
 
             // switch internal binary bitset functions
-            $this->fnDoRewind            = 'doRewindBin';
             $this->fnDoCount             = 'doCountBin';
             $this->fnDoGetOrdinals       = 'doGetOrdinalsBin';
             $this->fnDoGetBit            = 'doGetBitBin';
@@ -138,104 +132,174 @@ class EnumSet implements Iterator, Countable
         return $this->{$this->fnDoGetBit}(($this->enumeration)::get($enumerator)->getOrdinal());
     }
 
-    /* Iterator */
+    /* IteratorAggregate */
 
     /**
-     * Get the current enumerator
-     * @return Enum|null Returns the current enumerator or NULL on an invalid iterator position
+     * Create and return a new iterator
+     * @return Iterator
      */
-    public function current(): ?Enum
+    public function getIterator(): Iterator
     {
-        if ($this->valid()) {
-            return ($this->enumeration)::byOrdinal($this->ordinal);
-        }
+        return new class($this, $this->enumeration, $this->enumerationCount, $this->bitset) implements Iterator {
+            /**
+             * @var EnumSet
+             */
+            private $enumSet;
 
-        return null;
-    }
+            /**
+             * @var string
+             */
+            private $enumeration;
 
-    /**
-     * Get the ordinal number of the current iterator position
-     * @return int
-     */
-    public function key(): int
-    {
-        return $this->ordinal;
-    }
+            /**
+             * @var int
+             */
+            private $enumerationCount;
 
-    /**
-     * Go to the next valid iterator position.
-     * If no valid iterator position is found the iterator position will be the last possible + 1.
-     * @return void
-     */
-    public function next(): void
-    {
-        do {
-            if (++$this->ordinal >= $this->ordinalMax) {
-                $this->ordinal = $this->ordinalMax;
-                return;
+            /**
+             * @var int|string
+             */
+            private $bitset;
+
+            /**
+             * @var int
+             */
+            private $ordinal = -1;
+
+            /**
+             * @var string
+             */
+            private $fnDoRewind = 'doRewindInt';
+
+            /**
+             * Constructor.
+             * @param EnumSet    $enumSet
+             * @param string     $enumeration
+             * @param int        $enumerationCount
+             * @param int|string $bitset
+             */
+            public function __construct(EnumSet $enumSet, $enumeration, $enumerationCount, $bitset)
+            {
+                $this->enumSet          = $enumSet;
+                $this->enumeration      = $enumeration;
+                $this->enumerationCount = $enumerationCount;
+                $this->bitset           = $bitset;
+
+                // By default the bitset is initialized as integer bitset
+                // in case the enumeraton has more enumerators then integer bits
+                // we will switch this into a binary bitset
+                if ($this->enumerationCount > \PHP_INT_SIZE * 8) {
+                    $this->fnDoRewind = 'doRewindBin';
+                }
+
+                // go to the first valid iterator position (if any)
+                $this->next();
             }
-        } while (!$this->{$this->fnDoGetBit}($this->ordinal));
-    }
 
-    /**
-     * Go to the first valid iterator position.
-     * If no valid iterator position was found the iterator position will be 0.
-     * @return void
-     * @uses doRewindBin()
-     * @uses doRewindInt()
-     */
-    public function rewind(): void
-    {
-        $this->{$this->fnDoRewind}();
-    }
+            /**
+             * Get the current enumerator
+             * @return Enum Returns the current enumerator object
+             * @throws OutOfBoundsException On an invalid iterator position
+             */
+            public function current(): Enum
+            {
+                if (!$this->valid()) {
+                    throw new OutOfBoundsException('Invalid iterator position');
+                }
 
-    /**
-     * Go to the first valid iterator position.
-     * If no valid iterator position was found the iterator position will be 0.
-     *
-     * This is the binary bitset implementation.
-     *
-     * @return void
-     * @see rewind()
-     * @see doRewindInt()
-     */
-    private function doRewindBin(): void
-    {
-        if (\ltrim($this->bitset, "\0") !== '') {
-            $this->ordinal = -1;
-            $this->next();
-        } else {
-            $this->ordinal = 0;
-        }
-    }
+                return ($this->enumeration)::byOrdinal($this->ordinal);
+            }
 
-    /**
-     * Go to the first valid iterator position.
-     * If no valid iterator position was found the iterator position will be 0.
-     *
-     * This is the binary bitset implementation.
-     *
-     * @return void
-     * @see rewind()
-     * @see doRewindBin()
-     */
-    private function doRewindInt(): void
-    {
-        if ($this->bitset) {
-            $this->ordinal = -1;
-            $this->next();
-        } else {
-            $this->ordinal = 0;
-        }
-    }
+            /**
+             * Get the ordinal number of the current iterator position
+             * @return int The ordinal number of the current enumerator
+             * @throws OutOfBoundsException On an invalid iterator position
+             */
+            public function key(): int
+            {
+                if (!$this->valid()) {
+                    throw new OutOfBoundsException('Invalid iterator position');
+                }
 
-    /**
-     * Test if the iterator is in a valid state
-     * @return bool
-     */
-    public function valid(): bool
-    {
-        return $this->ordinal !== $this->ordinalMax && $this->{$this->fnDoGetBit}($this->ordinal);
+                return $this->ordinal;
+            }
+
+            /**
+             * Go to the next valid iterator position.
+             * If no valid iterator position is found the iterator position will be the last possible + 1.
+             * @return void
+             */
+            public function next(): void
+            {
+                do {
+                    if (++$this->ordinal >= $this->enumerationCount) {
+                        $this->ordinal = $this->enumerationCount;
+                        return;
+                    }
+                } while (!$this->enumSet->getBit($this->ordinal));
+            }
+
+            /**
+             * Go to the first valid iterator position.
+             * If no valid iterator position was found the iterator position will be 0.
+             * @return void
+             * @uses doRewindBin()
+             * @uses doRewindInt()
+             */
+            public function rewind(): void
+            {
+                $this->{$this->fnDoRewind}();
+            }
+
+            /**
+             * Go to the first valid iterator position.
+             * If no valid iterator position was found the iterator position will be 0.
+             *
+             * This is the binary bitset implementation.
+             *
+             * @return void
+             * @see rewind()
+             * @see doRewindInt()
+             */
+            private function doRewindBin(): void
+            {
+                if (\ltrim($this->bitset, "\0") !== '') {
+                    $this->ordinal = -1;
+                    $this->next();
+                } else {
+                    $this->ordinal = 0;
+                }
+            }
+
+            /**
+             * Go to the first valid iterator position.
+             * If no valid iterator position was found the iterator position will be 0.
+             *
+             * This is the integer bitset implementation.
+             *
+             * @return void
+             * @see rewind()
+             * @see doRewindBin()
+             */
+            private function doRewindInt(): void
+            {
+                if ($this->bitset) {
+                    $this->ordinal = -1;
+                    $this->next();
+                } else {
+                    $this->ordinal = 0;
+                }
+            }
+
+            /**
+             * Test if the current iterator position is valid
+             * @return bool
+             */
+            public function valid(): bool
+            {
+                return $this->ordinal !== $this->enumerationCount && $this->enumSet->getBit($this->ordinal);
+            }
+        };
     }
 
     /* Countable */
@@ -500,7 +564,7 @@ class EnumSet implements Iterator, Countable
     private function doGetOrdinalsInt(): array
     {
         $ordinals   = [];
-        $ordinalMax = $this->ordinalMax;
+        $ordinalMax = $this->enumerationCount;
         $bitset     = $this->bitset;
         for ($ord = 0; $ord < $ordinalMax; ++$ord) {
             if ($bitset & (1 << $ord)) {
@@ -590,7 +654,7 @@ class EnumSet implements Iterator, Countable
     private function doGetBinaryBitsetLeInt(): string
     {
         $bin = \pack(\PHP_INT_SIZE === 8 ? 'P' : 'V', $this->bitset);
-        return \substr($bin, 0, (int)\ceil($this->ordinalMax / 8));
+        return \substr($bin, 0, (int)\ceil($this->enumerationCount / 8));
     }
 
     /**
@@ -607,9 +671,6 @@ class EnumSet implements Iterator, Countable
     public function setBinaryBitsetLe(string $bitset): void
     {
         $this->{$this->fnDoSetBinaryBitsetLe}($bitset);
-
-        // reset the iterator position
-        $this->rewind();
     }
 
     /**
@@ -639,7 +700,7 @@ class EnumSet implements Iterator, Countable
         }
 
         // truncate out-of-range bits of last byte
-        $lastByteMaxOrd = $this->ordinalMax % 8;
+        $lastByteMaxOrd = $this->enumerationCount % 8;
         if ($lastByteMaxOrd !== 0) {
             $lastByte         = $bitset[-1];
             $lastByteExpected = \chr((1 << $lastByteMaxOrd) - 1) & $lastByte;
@@ -678,7 +739,7 @@ class EnumSet implements Iterator, Countable
             $int |= $ord << (8 * $i);
         }
 
-        if ($int & (~0 << $this->ordinalMax)) {
+        if ($int & (~0 << $this->enumerationCount)) {
             throw new InvalidArgumentException('out-of-range bits detected');
         }
 
@@ -720,8 +781,8 @@ class EnumSet implements Iterator, Countable
      */
     public function getBit(int $ordinal): bool
     {
-        if ($ordinal < 0 || $ordinal > $this->ordinalMax) {
-            throw new InvalidArgumentException("Ordinal number must be between 0 and {$this->ordinalMax}");
+        if ($ordinal < 0 || $ordinal > $this->enumerationCount) {
+            throw new InvalidArgumentException("Ordinal number must be between 0 and {$this->enumerationCount}");
         }
 
         return $this->{$this->fnDoGetBit}($ordinal);
@@ -771,8 +832,8 @@ class EnumSet implements Iterator, Countable
      */
     public function setBit(int $ordinal, bool $bit): void
     {
-        if ($ordinal < 0 || $ordinal > $this->ordinalMax) {
-            throw new InvalidArgumentException("Ordinal number must be between 0 and {$this->ordinalMax}");
+        if ($ordinal < 0 || $ordinal > $this->enumerationCount) {
+            throw new InvalidArgumentException("Ordinal number must be between 0 and {$this->enumerationCount}");
         }
 
         if ($bit) {

--- a/tests/MabeEnumTest/EnumSetIteratorTest.php
+++ b/tests/MabeEnumTest/EnumSetIteratorTest.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace MabeEnumTest;
+
+use InvalidArgumentException;
+use MabeEnum\EnumSet;
+use MabeEnumTest\TestAsset\EmptyEnum;
+use MabeEnumTest\TestAsset\Enum31;
+use MabeEnumTest\TestAsset\EnumBasic;
+use MabeEnumTest\TestAsset\EnumInheritance;
+use MabeEnumTest\TestAsset\Enum32;
+use MabeEnumTest\TestAsset\Enum64;
+use MabeEnumTest\TestAsset\Enum65;
+use MabeEnumTest\TestAsset\Enum66;
+use OutOfBoundsException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for the class MabeEnum\EnumSet
+ *
+ * @copyright 2019 Marc Bennewitz
+ * @license http://github.com/marc-mabe/php-enum/blob/master/LICENSE.txt New BSD License
+ * @link http://github.com/marc-mabe/php-enum for the canonical source repository
+ */
+class EnumSetIteratorTest extends TestCase
+{
+    public function testIterateEmpty()
+    {
+        $set = new EnumSet(EnumBasic::class);
+
+        $this->assertSame([], iterator_to_array($set->getIterator()));
+    }
+
+    public function testIterateOrdered()
+    {
+        $set = new EnumSet(EnumBasic::class);
+        $set->attach(EnumBasic::FOUR);
+        $set->attach(EnumBasic::TWO);
+        $set->attach(EnumBasic::SEVEN);
+
+        $this->assertSame([
+            1 => EnumBasic::TWO(),
+            3 => EnumBasic::FOUR(),
+            6 => EnumBasic::SEVEN(),
+        ], iterator_to_array($set));
+    }
+
+    public function testStartAtFirstValidPosition()
+    {
+        $set = new EnumSet(EnumBasic::class);
+        $set->attach(EnumBasic::SEVEN);
+
+        $it = $set->getIterator();
+        $this->assertSame(EnumBasic::SEVEN(), $it->current());
+        $this->assertSame(EnumBasic::SEVEN()->getOrdinal(), $it->key());
+    }
+
+    public function testCurrentKeyOnEmpty()
+    {
+        $set = new EnumSet(EnumBasic::class);
+
+        $it = $set->getIterator();
+        $this->assertFalse($it->valid());
+
+        $this->expectException(OutOfBoundsException::class);
+        $it->key();
+    }
+
+    public function testCurrentItemOnEmpty()
+    {
+        $set = new EnumSet(EnumBasic::class);
+
+        $it = $set->getIterator();
+        $this->assertFalse($it->valid());
+
+        $this->expectException(OutOfBoundsException::class);
+        $it->current();
+    }
+
+    /**
+     * @param string $enumeration
+     * @dataProvider getIntegerEnumerations
+     */
+    public function testNextCurrentItemOutOfRange(string $enumeration)
+    {
+        $set   = new EnumSet($enumeration);
+        $count = count($enumeration::getConstants());
+        $last  = $enumeration::byOrdinal($count - 1);
+        $set->attach($last);
+
+        $it = $set->getIterator();
+        $this->assertTrue($it->valid());
+        $this->assertSame($last, $it->current());
+        $this->assertSame($last->getOrdinal(), $it->key());
+
+        // go to the first out-of-range position
+        $it->next();
+        $this->assertFalse($it->valid());
+
+        $this->expectException(OutOfBoundsException::class);
+        $it->current();
+    }
+
+    /**
+     * @param string $enumeration
+     * @dataProvider getIntegerEnumerations
+     */
+    public function testNextCurrentKeyOutOfRange(string $enumeration)
+    {
+        $set   = new EnumSet($enumeration);
+        $count = count($enumeration::getConstants());
+        $last  = $enumeration::byOrdinal($count - 1);
+        $set->attach($last);
+
+        $it = $set->getIterator();
+        $this->assertTrue($it->valid());
+        $this->assertSame($last, $it->current());
+        $this->assertSame($last->getOrdinal(), $it->key());
+
+        // go to the first out-of-range position
+        $it->next();
+        $this->assertFalse($it->valid());
+
+        $this->expectException(OutOfBoundsException::class);
+        $it->key();
+    }
+
+    /**
+     * @param string $enumeration
+     * @dataProvider getIntegerEnumerations
+     */
+    public function testRewindEmpty(string $enumeration)
+    {
+        $set = new EnumSet($enumeration);
+        $it  = $set->getIterator();
+
+        $it->rewind();
+        $this->assertFalse($it->valid());
+
+        $this->expectException(OutOfBoundsException::class);
+        $it->current();
+    }
+
+    /**
+     * @param string $enumeration
+     * @dataProvider getIntegerEnumerations
+     */
+    public function testRewindFirst(string $enumeration)
+    {
+        $set   = new EnumSet($enumeration);
+        $first = $enumeration::byOrdinal(0);
+        $set->attach($first);
+
+        $it = $set->getIterator();
+        $it->next();
+        $this->assertFalse($it->valid());
+
+        $it->rewind();
+        $this->assertTrue($it->valid());
+        $this->assertSame($first, $it->current());
+        $this->assertSame(0, $it->key());
+    }
+
+    /**
+     * Data provider for all available integer enumerators
+     * @return array
+     */
+    public function getIntegerEnumerations()
+    {
+        return [
+            [Enum31::class],
+            [Enum32::class],
+            [Enum64::class],
+            [Enum65::class],
+            [Enum66::class]
+        ];
+    }
+}

--- a/tests/MabeEnumTest/EnumSetTest.php
+++ b/tests/MabeEnumTest/EnumSetTest.php
@@ -25,134 +25,60 @@ class EnumSetTest extends TestCase
 {
     public function testBasic()
     {
-        $enumSet = new EnumSet(EnumBasic::class);
-        $this->assertSame(EnumBasic::class, $enumSet->getEnumeration());
+        $set = new EnumSet(EnumBasic::class);
+        $this->assertSame(EnumBasic::class, $set->getEnumeration());
 
         $enum1  = EnumBasic::ONE();
         $enum2  = EnumBasic::TWO();
 
-        $this->assertFalse($enumSet->contains($enum1));
-        $this->assertNull($enumSet->attach($enum1));
-        $this->assertTrue($enumSet->contains($enum1));
+        $this->assertFalse($set->contains($enum1));
+        $this->assertNull($set->attach($enum1));
+        $this->assertTrue($set->contains($enum1));
 
-        $this->assertFalse($enumSet->contains($enum2));
-        $this->assertNull($enumSet->attach($enum2));
-        $this->assertTrue($enumSet->contains($enum2));
+        $this->assertFalse($set->contains($enum2));
+        $this->assertNull($set->attach($enum2));
+        $this->assertTrue($set->contains($enum2));
 
-        $this->assertNull($enumSet->detach($enum1));
-        $this->assertFalse($enumSet->contains($enum1));
+        $this->assertNull($set->detach($enum1));
+        $this->assertFalse($set->contains($enum1));
 
-        $this->assertNull($enumSet->detach($enum2));
-        $this->assertFalse($enumSet->contains($enum2));
+        $this->assertNull($set->detach($enum2));
+        $this->assertFalse($set->contains($enum2));
     }
 
     public function testBasicWithConstantValuesAsEnums()
     {
-        $enumSet = new EnumSet(EnumBasic::class);
+        $set = new EnumSet(EnumBasic::class);
 
         $enum1  = EnumBasic::ONE;
         $enum2  = EnumBasic::TWO;
 
-        $this->assertFalse($enumSet->contains($enum1));
-        $this->assertNull($enumSet->attach($enum1));
-        $this->assertTrue($enumSet->contains($enum1));
+        $this->assertFalse($set->contains($enum1));
+        $this->assertNull($set->attach($enum1));
+        $this->assertTrue($set->contains($enum1));
 
-        $this->assertFalse($enumSet->contains($enum2));
-        $this->assertNull($enumSet->attach($enum2));
-        $this->assertTrue($enumSet->contains($enum2));
+        $this->assertFalse($set->contains($enum2));
+        $this->assertNull($set->attach($enum2));
+        $this->assertTrue($set->contains($enum2));
 
-        $this->assertNull($enumSet->detach($enum1));
-        $this->assertFalse($enumSet->contains($enum1));
+        $this->assertNull($set->detach($enum1));
+        $this->assertFalse($set->contains($enum1));
 
-        $this->assertNull($enumSet->detach($enum2));
-        $this->assertFalse($enumSet->contains($enum2));
+        $this->assertNull($set->detach($enum2));
+        $this->assertFalse($set->contains($enum2));
     }
 
     public function testUnique()
     {
-        $enumSet = new EnumSet(EnumBasic::class);
+        $set = new EnumSet(EnumBasic::class);
 
-        $enumSet->attach(EnumBasic::ONE());
-        $enumSet->attach(EnumBasic::ONE);
+        $set->attach(EnumBasic::ONE());
+        $set->attach(EnumBasic::ONE);
 
-        $enumSet->attach(EnumBasic::TWO());
-        $enumSet->attach(EnumBasic::TWO);
+        $set->attach(EnumBasic::TWO());
+        $set->attach(EnumBasic::TWO);
 
-        $this->assertSame(2, $enumSet->count());
-    }
-
-    public function testIterateOrdered()
-    {
-        $enumSet = new EnumSet(EnumBasic::class);
-
-        // an empty enum set needs to be invalid, starting by 0
-        $this->assertSame(0, $enumSet->count());
-        $this->assertFalse($enumSet->valid());
-        $this->assertNull($enumSet->current());
-
-        // attach
-        $enum1 = EnumBasic::ONE();
-        $enum2 = EnumBasic::TWO();
-        $enumSet->attach($enum1);
-        $enumSet->attach($enum2);
-
-        // a not empty enum set should be valid, starting by 0 (if not iterated)
-        $enumSet->rewind();
-        $this->assertSame(2, $enumSet->count());
-        $this->assertTrue($enumSet->valid());
-        $this->assertSame($enum1->getOrdinal(), $enumSet->key());
-        $this->assertSame($enum1, $enumSet->current());
-
-        // go to the next element (last)
-        $this->assertNull($enumSet->next());
-        $this->assertTrue($enumSet->valid());
-        $this->assertSame($enum2->getOrdinal(), $enumSet->key());
-        $this->assertSame($enum2, $enumSet->current());
-
-        // go to the next element (out of range)
-        $this->assertNull($enumSet->next());
-        $this->assertFalse($enumSet->valid());
-        $this->assertNull($enumSet->current());
-
-        // rewind will set the iterator position back to 0
-        $enumSet->rewind();
-        $this->assertTrue($enumSet->valid());
-        $this->assertSame(0, $enumSet->key());
-        $this->assertSame($enum1, $enumSet->current());
-    }
-
-    public function testIterateAndDetach()
-    {
-        $enumSet = new EnumSet(EnumInheritance::class);
-
-        $enum1 = EnumInheritance::ONE();
-        $enum2 = EnumInheritance::TWO();
-        $enum3 = EnumInheritance::INHERITANCE();
-
-        // attach
-        $enumSet->attach($enum1);
-        $enumSet->attach($enum2);
-        $enumSet->attach($enum3);
-
-        // go to the next entry
-        $enumSet->next();
-        $this->assertSame($enum2, $enumSet->current());
-
-        // detach current entry
-        $enumSet->detach($enumSet->current());
-        $this->assertFalse($enumSet->valid());
-        $this->assertNull($enumSet->current());
-        $this->assertSame($enum2->getOrdinal(), $enumSet->key());
-
-        // go to the next entry should be the last entry
-        $enumSet->next();
-        $this->assertSame($enum3, $enumSet->current());
-
-        // detech the last entry
-        $enumSet->detach($enumSet->current());
-        $this->assertFalse($enumSet->valid());
-        $this->assertNull($enumSet->current());
-        $this->assertSame($enum3->getOrdinal(), $enumSet->key());
+        $this->assertSame(2, $set->count());
     }
 
     public function testConstructThrowsInvalidArgumentExceptionIfEnumClassDoesNotExtendBaseEnum()
@@ -163,319 +89,264 @@ class EnumSetTest extends TestCase
 
     public function testInitEnumThrowsInvalidArgumentExceptionOnInvalidEnum()
     {
-        $enumSet = new EnumSet(EnumBasic::class);
+        $set = new EnumSet(EnumBasic::class);
         $this->expectException(InvalidArgumentException::class);
-        $this->assertFalse($enumSet->contains(EnumInheritance::INHERITANCE()));
+        $this->assertFalse($set->contains(EnumInheritance::INHERITANCE()));
     }
 
-    public function testIterateOutOfRangeIfLastOrdinalEnumIsSet()
+    /**
+     * @param string $enumeration
+     * @dataProvider getIntegerEnumerations
+     */
+    public function testSetAllEnumerators(string $enumeration)
     {
-        $enumSet = new EnumSet(EnumBasic::class);
-        $enum    = EnumBasic::byOrdinal(count(EnumBasic::getConstants()) - 1);
-
-        $enumSet->attach($enum);
-        $enumSet->rewind();
-        $this->assertSame($enum, $enumSet->current());
-
-        // go to the next entry results in out of range
-        $enumSet->next();
-        $this->assertFalse($enumSet->valid());
-        $this->assertSame($enum->getOrdinal() + 1, $enumSet->key());
-
-        // go more over doesn't change iterator position
-        $enumSet->next();
-        $this->assertFalse($enumSet->valid());
-        $this->assertSame($enum->getOrdinal() + 1, $enumSet->key());
-    }
-
-    public function testRewindIntFirstOnEmptySet()
-    {
-        $enumSet = new EnumSet(EnumBasic::class);
-
-        $enumSet->attach(EnumBasic::TWO);
-        $enumSet->rewind();
-        $this->assertGreaterThan(0, $enumSet->key());
-
-        $enumSet->detach(EnumBasic::TWO);
-        $enumSet->rewind();
-        $this->assertSame(0, $enumSet->key());
-    }
-
-    public function testRewindBinFirstOnEmptySet()
-    {
-        $enumSet = new EnumSet(Enum66::class);
-
-        $enumSet->attach(Enum66::TWO);
-        $enumSet->rewind();
-        $this->assertGreaterThan(0, $enumSet->key());
-
-        $enumSet->detach(Enum66::TWO);
-        $enumSet->rewind();
-        $this->assertSame(0, $enumSet->key());
-    }
-
-    public function test32EnumerationsSet()
-    {
-        $enumSet = new EnumSet(Enum32::class);
-        foreach (Enum32::getConstants() as $name => $value) {
-            $this->assertFalse($enumSet->contains($value));
-            $enumSet->attach($value);
-            $this->assertTrue($enumSet->contains($value));
+        $set = new EnumSet($enumeration);
+        foreach ($enumeration::getConstants() as $value) {
+            $this->assertFalse($set->contains($value));
+            $set->attach($value);
+            $this->assertTrue($set->contains($value));
         }
 
-        $this->assertSame(32, $enumSet->count());
+        $this->assertSame(count($enumeration::getConstants()), $set->count());
 
         $expectedOrdinal = 0;
-        foreach ($enumSet as $ordinal => $enum) {
+        foreach ($set as $ordinal => $enum) {
             $this->assertSame($expectedOrdinal, $ordinal);
             $this->assertSame($expectedOrdinal, $enum->getOrdinal());
             $expectedOrdinal++;
         }
     }
 
-    public function test64EnumerationsSet()
+    /**
+     * Data provider for all available integer enumerators
+     * @return array
+     */
+    public function getIntegerEnumerations()
     {
-        $enumSet = new EnumSet(Enum64::class);
-        foreach (Enum64::getConstants() as $name => $value) {
-            $this->assertFalse($enumSet->contains($value));
-            $enumSet->attach($value);
-            $this->assertTrue($enumSet->contains($value));
-        }
-
-        $this->assertSame(64, $enumSet->count());
-
-        $expectedOrdinal = 0;
-        foreach ($enumSet as $ordinal => $enum) {
-            $this->assertSame($expectedOrdinal, $ordinal);
-            $this->assertSame($expectedOrdinal, $enum->getOrdinal());
-            $expectedOrdinal++;
-        }
-    }
-
-    public function test65EnumerationsSet()
-    {
-        $enum = new EnumSet(Enum65::class);
-
-        $this->assertNull($enum->attach(Enum65::byOrdinal(64)));
-        $enum->next();
-        $this->assertTrue($enum->valid());
+        return [
+            [Enum31::class],
+            [Enum32::class],
+            [Enum64::class],
+            [Enum65::class],
+            [Enum66::class]
+        ];
     }
 
     public function testGetBit()
     {
-        $enumSet = new EnumSet(EnumBasic::class);
-        $enumSet->attach(EnumBasic::TWO);
+        $set = new EnumSet(EnumBasic::class);
+        $set->attach(EnumBasic::TWO);
 
-        $this->assertFalse($enumSet->getBit(EnumBasic::ONE()->getOrdinal()));
-        $this->assertTrue($enumSet->getBit(EnumBasic::TWO()->getOrdinal()));
+        $this->assertFalse($set->getBit(EnumBasic::ONE()->getOrdinal()));
+        $this->assertTrue($set->getBit(EnumBasic::TWO()->getOrdinal()));
     }
 
-    public function testGetBitOutOfRangeOrdinal()
+    public function testGetBitOutOfRange()
     {
-        $enumSet = new EnumSet(EnumBasic::class);
+        $set = new EnumSet(EnumBasic::class);
 
         $this->expectException(InvalidArgumentException::class);
-        $enumSet->getBit(100);
+        $set->getBit(100);
     }
 
     public function testSetBit()
     {
-        $enumSet = new EnumSet(EnumBasic::class);
+        $set = new EnumSet(EnumBasic::class);
 
-        $enumSet->setBit(EnumBasic::TWO()->getOrdinal(), true);
-        $this->assertTrue($enumSet->getBit(EnumBasic::TWO()->getOrdinal()));
+        $set->setBit(EnumBasic::TWO()->getOrdinal(), true);
+        $this->assertTrue($set->getBit(EnumBasic::TWO()->getOrdinal()));
 
-        $enumSet->setBit(EnumBasic::TWO()->getOrdinal(), false);
-        $this->assertFalse($enumSet->getBit(EnumBasic::TWO()->getOrdinal()));
+        $set->setBit(EnumBasic::TWO()->getOrdinal(), false);
+        $this->assertFalse($set->getBit(EnumBasic::TWO()->getOrdinal()));
     }
 
-    public function testSetBitOutOfRangeOrdinal()
+    public function testSetBitOutOfRange()
     {
-        $enumSet = new EnumSet(EnumBasic::class);
+        $set = new EnumSet(EnumBasic::class);
 
         $this->expectException(InvalidArgumentException::class);
-        $enumSet->setBit(100, true);
+        $set->setBit(100, true);
     }
 
     public function testGetBinaryBitsetLe()
     {
-        $enumSet = new EnumSet(Enum65::class);
+        $set = new EnumSet(Enum65::class);
         
         $enum1 = Enum65::ONE;
         $enum2 = Enum65::TWO;
         $enum3 = Enum65::SIXTYFIVE;
         $enum4 = Enum65::SIXTYFOUR;
 
-        $this->assertNull($enumSet->attach($enum1));
-        $this->assertSame("\x01\x00\x00\x00\x00\x00\x00\x00\x00", $enumSet->getBinaryBitsetLe());
-        $this->assertTrue($enumSet->contains($enum1));
+        $this->assertNull($set->attach($enum1));
+        $this->assertSame("\x01\x00\x00\x00\x00\x00\x00\x00\x00", $set->getBinaryBitsetLe());
+        $this->assertTrue($set->contains($enum1));
 
-        $this->assertNull($enumSet->attach($enum2));
-        $this->assertSame("\x03\x00\x00\x00\x00\x00\x00\x00\x00", $enumSet->getBinaryBitsetLe());
-        $this->assertTrue($enumSet->contains($enum2));
+        $this->assertNull($set->attach($enum2));
+        $this->assertSame("\x03\x00\x00\x00\x00\x00\x00\x00\x00", $set->getBinaryBitsetLe());
+        $this->assertTrue($set->contains($enum2));
 
-        $this->assertNull($enumSet->attach($enum3));
-        $this->assertSame("\x03\x00\x00\x00\x00\x00\x00\x00\x01", $enumSet->getBinaryBitsetLe());
-        $this->assertTrue($enumSet->contains($enum3));
+        $this->assertNull($set->attach($enum3));
+        $this->assertSame("\x03\x00\x00\x00\x00\x00\x00\x00\x01", $set->getBinaryBitsetLe());
+        $this->assertTrue($set->contains($enum3));
 
-        $this->assertNull($enumSet->attach($enum4));
-        $this->assertSame("\x03\x00\x00\x00\x00\x00\x00\x80\x01", $enumSet->getBinaryBitsetLe());
-        $this->assertTrue($enumSet->contains($enum4));
+        $this->assertNull($set->attach($enum4));
+        $this->assertSame("\x03\x00\x00\x00\x00\x00\x00\x80\x01", $set->getBinaryBitsetLe());
+        $this->assertTrue($set->contains($enum4));
         
-        $this->assertSame(4, $enumSet->count());
+        $this->assertSame(4, $set->count());
 
-        $this->assertNull($enumSet->detach($enum2));
-        $this->assertSame("\x01\x00\x00\x00\x00\x00\x00\x80\x01", $enumSet->getBinaryBitsetLe());
-        $this->assertFalse($enumSet->contains($enum2));
+        $this->assertNull($set->detach($enum2));
+        $this->assertSame("\x01\x00\x00\x00\x00\x00\x00\x80\x01", $set->getBinaryBitsetLe());
+        $this->assertFalse($set->contains($enum2));
         
-        $this->assertSame(3, $enumSet->count());
+        $this->assertSame(3, $set->count());
     }
 
     public function testGetBinaryBitsetBe()
     {
-        $enumSet = new EnumSet(Enum65::class);
+        $set = new EnumSet(Enum65::class);
         
         $enum1 = Enum65::ONE;
         $enum2 = Enum65::TWO;
         $enum3 = Enum65::SIXTYFIVE;
         $enum4 = Enum65::SIXTYFOUR;
 
-        $this->assertNull($enumSet->attach($enum1));
-        $this->assertSame("\x00\x00\x00\x00\x00\x00\x00\x00\x01", $enumSet->getBinaryBitsetBe());
-        $this->assertTrue($enumSet->contains($enum1));
+        $this->assertNull($set->attach($enum1));
+        $this->assertSame("\x00\x00\x00\x00\x00\x00\x00\x00\x01", $set->getBinaryBitsetBe());
+        $this->assertTrue($set->contains($enum1));
 
-        $this->assertNull($enumSet->attach($enum2));
-        $this->assertSame("\x00\x00\x00\x00\x00\x00\x00\x00\x03", $enumSet->getBinaryBitsetBe());
-        $this->assertTrue($enumSet->contains($enum2));
+        $this->assertNull($set->attach($enum2));
+        $this->assertSame("\x00\x00\x00\x00\x00\x00\x00\x00\x03", $set->getBinaryBitsetBe());
+        $this->assertTrue($set->contains($enum2));
 
-        $this->assertNull($enumSet->attach($enum3));
-        $this->assertSame("\x01\x00\x00\x00\x00\x00\x00\x00\x03", $enumSet->getBinaryBitsetBe());
-        $this->assertTrue($enumSet->contains($enum3));
+        $this->assertNull($set->attach($enum3));
+        $this->assertSame("\x01\x00\x00\x00\x00\x00\x00\x00\x03", $set->getBinaryBitsetBe());
+        $this->assertTrue($set->contains($enum3));
 
-        $this->assertNull($enumSet->attach($enum4));
-        $this->assertSame("\x01\x80\x00\x00\x00\x00\x00\x00\x03", $enumSet->getBinaryBitsetBe());
-        $this->assertTrue($enumSet->contains($enum4));
+        $this->assertNull($set->attach($enum4));
+        $this->assertSame("\x01\x80\x00\x00\x00\x00\x00\x00\x03", $set->getBinaryBitsetBe());
+        $this->assertTrue($set->contains($enum4));
         
-        $this->assertSame(4, $enumSet->count());
+        $this->assertSame(4, $set->count());
 
-        $this->assertNull($enumSet->detach($enum2));
-        $this->assertSame("\x01\x80\x00\x00\x00\x00\x00\x00\x01", $enumSet->getBinaryBitsetBe());
-        $this->assertFalse($enumSet->contains($enum2));
+        $this->assertNull($set->detach($enum2));
+        $this->assertSame("\x01\x80\x00\x00\x00\x00\x00\x00\x01", $set->getBinaryBitsetBe());
+        $this->assertFalse($set->contains($enum2));
         
-        $this->assertSame(3, $enumSet->count());
+        $this->assertSame(3, $set->count());
     }
 
     public function testSetBinaryBitsetLeBin()
     {
-        $enumSet = new EnumSet(Enum65::class);
-        $enumSet->setBinaryBitsetLe("\x01\x00\x00\x00\x00\x00\x00\x80\x01");
+        $set = new EnumSet(Enum65::class);
+        $set->setBinaryBitsetLe("\x01\x00\x00\x00\x00\x00\x00\x80\x01");
 
-        $this->assertContains(Enum65::ONE(), $enumSet);
-        $this->assertNotContains(Enum65::TWO(), $enumSet);
-        $this->assertContains(Enum65::SIXTYFIVE(), $enumSet);
-        $this->assertContains(Enum65::SIXTYFOUR(), $enumSet);
-        $this->assertSame(3, $enumSet->count());
+        $this->assertContains(Enum65::ONE(), $set);
+        $this->assertNotContains(Enum65::TWO(), $set);
+        $this->assertContains(Enum65::SIXTYFIVE(), $set);
+        $this->assertContains(Enum65::SIXTYFOUR(), $set);
+        $this->assertSame(3, $set->count());
     }
 
     public function testSetBinaryBitsetLeBinShort()
     {
-        $enumSet = new EnumSet(Enum65::class);
-        $enumSet->setBinaryBitsetLe("\x0A");
-        $this->assertSame("\x0A\x00\x00\x00\x00\x00\x00\x00\x00", $enumSet->getBinaryBitsetLe());
+        $set = new EnumSet(Enum65::class);
+        $set->setBinaryBitsetLe("\x0A");
+        $this->assertSame("\x0A\x00\x00\x00\x00\x00\x00\x00\x00", $set->getBinaryBitsetLe());
     }
 
     public function testSetBinaryBitsetLeBinLong()
     {
-        $enumSet = new EnumSet(Enum65::class);
+        $set = new EnumSet(Enum65::class);
         $bitset = "\x0A\xFF\x00\x00\x00\x00\x00\x00\x00";
-        $enumSet->setBinaryBitsetLe($bitset . "\x00\x00\x00\x00\x00\x00\x00");
-        $this->assertSame($bitset, $enumSet->getBinaryBitsetLe());
+        $set->setBinaryBitsetLe($bitset . "\x00\x00\x00\x00\x00\x00\x00");
+        $this->assertSame($bitset, $set->getBinaryBitsetLe());
     }
 
     public function testSetBinaryBitsetLeBinOutOfRangeBitsOfExtendedBytes1()
     {
-        $enumSet = new EnumSet(Enum65::class);
+        $set = new EnumSet(Enum65::class);
 
         $this->expectException(InvalidArgumentException::class, 'Out-Of-Range');
-        $enumSet->setBinaryBitsetLe("\xff\xff\xff\xff\xff\xff\xff\xff\x00\x02");
+        $set->setBinaryBitsetLe("\xff\xff\xff\xff\xff\xff\xff\xff\x00\x02");
     }
 
     public function testSetBinaryBitsetLeBinOutOfRangeBitsOfExtendedBytes2()
     {
-        $enumSet = new EnumSet(Enum65::class);
+        $set = new EnumSet(Enum65::class);
 
         $this->expectException(InvalidArgumentException::class, 'Out-Of-Range');
-        $enumSet->setBinaryBitsetLe("\xff\xff\xff\xff\xff\xff\xff\xff\x02");
+        $set->setBinaryBitsetLe("\xff\xff\xff\xff\xff\xff\xff\xff\x02");
     }
 
     public function testSetBinaryBitsetLeBinOutOfRangeBitsOfLastValidByte()
     {
         // using Enum65 to detect Out-Of-Range bits of last valid byte
         // Enum65 has max. ordinal number of 2 of the last byte. -> 0001
-        $enumSet   = new EnumSet(Enum65::class);
-        $bitset    = $enumSet->getBinaryBitsetLe();
+        $set   = new EnumSet(Enum65::class);
+        $bitset    = $set->getBinaryBitsetLe();
         $newBitset = substr($bitset, 0, -1) . "\x02";
 
         $this->expectException(InvalidArgumentException::class, 'Out-Of-Range');
-        $enumSet->setBinaryBitsetLe($newBitset);
+        $set->setBinaryBitsetLe($newBitset);
     }
 
     public function testSetBinaryBitsetLeInt()
     {
-        $enumSet = new EnumSet(Enum32::class);
-        $enumSet->setBinaryBitsetLe("\x01\x00\x80\x01");
-        $this->assertContains(Enum32::ONE(), $enumSet);
-        $this->assertNotContains(Enum32::TWO(), $enumSet);
-        $this->assertContains(Enum32::TWENTYFOUR(), $enumSet);
-        $this->assertContains(Enum32::TWENTYFIVE(), $enumSet);
-        $this->assertSame(3, $enumSet->count());
+        $set = new EnumSet(Enum32::class);
+        $set->setBinaryBitsetLe("\x01\x00\x80\x01");
+        $this->assertContains(Enum32::ONE(), $set);
+        $this->assertNotContains(Enum32::TWO(), $set);
+        $this->assertContains(Enum32::TWENTYFOUR(), $set);
+        $this->assertContains(Enum32::TWENTYFIVE(), $set);
+        $this->assertSame(3, $set->count());
     }
 
     public function testSetBinaryBitsetLeIntShort()
     {
-        $enumSet = new EnumSet(Enum32::class);
-        $enumSet->setBinaryBitsetLe("\x0A");
-        $this->assertSame("\x0A\x00\x00\x00", $enumSet->getBinaryBitsetLe());
+        $set = new EnumSet(Enum32::class);
+        $set->setBinaryBitsetLe("\x0A");
+        $this->assertSame("\x0A\x00\x00\x00", $set->getBinaryBitsetLe());
     }
 
     public function testSetBinaryBitsetLeIntOutOfRangeBitsOfExtendedBytes1()
     {
-        $enumSet = new EnumSet(EnumBasic::class);
+        $set = new EnumSet(EnumBasic::class);
 
         $this->expectException(InvalidArgumentException::class, 'Out-Of-Range');
-        $enumSet->setBinaryBitsetLe("\x0A\xFF\x02");
+        $set->setBinaryBitsetLe("\x0A\xFF\x02");
     }
 
     public function testSetBinaryBitsetLeIntOutOfRangeBitsOfExtendedBytes2()
     {
-        $enumSet = new EnumSet(EnumBasic::class);
+        $set = new EnumSet(EnumBasic::class);
 
         $this->expectException(InvalidArgumentException::class, 'Out-Of-Range');
-        $enumSet->setBinaryBitsetLe("\x01\x01\x01\x01\x01\x01\x01\x01\x01");
+        $set->setBinaryBitsetLe("\x01\x01\x01\x01\x01\x01\x01\x01\x01");
     }
 
     public function testSetBinaryBitsetLeIntOutOfRangeBitsOfLastValidByte()
     {
         // using Enum65 to detect Out-Of-Range bits of last valid byte
         // Enum65 has max. ordinal number of 2 of the last byte. -> 0001
-        $enumSet   = new EnumSet(Enum31::class);
-        $bitset    = $enumSet->getBinaryBitsetLe();
+        $set   = new EnumSet(Enum31::class);
+        $bitset    = $set->getBinaryBitsetLe();
         $newBitset = substr($bitset, 0, -1) . "\xFF";
 
         $this->expectException(InvalidArgumentException::class, 'Out-Of-Range');
-        $enumSet->setBinaryBitsetLe($newBitset);
+        $set->setBinaryBitsetLe($newBitset);
     }
 
     public function testSetBinaryBitsetBe()
     {
-        $enumSet = new EnumSet(Enum65::class);
-        $enumSet->setBinaryBitsetBe("\x01\x80\x00\x00\x00\x00\x00\x00\x01");
+        $set = new EnumSet(Enum65::class);
+        $set->setBinaryBitsetBe("\x01\x80\x00\x00\x00\x00\x00\x00\x01");
 
-        $this->assertTrue($enumSet->contains(Enum65::ONE));
-        $this->assertFalse($enumSet->contains(Enum65::TWO));
-        $this->assertTrue($enumSet->contains(Enum65::SIXTYFIVE));
-        $this->assertTrue($enumSet->contains(Enum65::SIXTYFOUR));
-        $this->assertTrue($enumSet->count() == 3);
+        $this->assertTrue($set->contains(Enum65::ONE));
+        $this->assertFalse($set->contains(Enum65::TWO));
+        $this->assertTrue($set->contains(Enum65::SIXTYFIVE));
+        $this->assertTrue($set->contains(Enum65::SIXTYFOUR));
+        $this->assertTrue($set->count() == 3);
     }
 
     public function testCountingEmptyEnumEmptySet()
@@ -487,27 +358,27 @@ class EnumSetTest extends TestCase
     public function testCountSingleBit32()
     {
         foreach (Enum32::getEnumerators() as $enum) {
-            $enumSet = new EnumSet(Enum32::class);
-            $enumSet->attach($enum);
-            $this->assertSame(1, $enumSet->count());
+            $set = new EnumSet(Enum32::class);
+            $set->attach($enum);
+            $this->assertSame(1, $set->count());
         }
     }
 
     public function testCountSingleBit64()
     {
         foreach (Enum64::getEnumerators() as $enum) {
-            $enumSet = new EnumSet(Enum64::class);
-            $enumSet->attach($enum);
-            $this->assertSame(1, $enumSet->count());
+            $set = new EnumSet(Enum64::class);
+            $set->attach($enum);
+            $this->assertSame(1, $set->count());
         }
     }
 
     public function testCountSingleBit66()
     {
         foreach (Enum66::getEnumerators() as $enum) {
-            $enumSet = new EnumSet(Enum66::class);
-            $enumSet->attach($enum);
-            $this->assertSame(1, $enumSet->count());
+            $set = new EnumSet(Enum66::class);
+            $set->attach($enum);
+            $this->assertSame(1, $set->count());
         }
     }
 
@@ -673,28 +544,6 @@ class EnumSetTest extends TestCase
         $this->assertSame(range(0, count(Enum66::getConstants()) - 1), $set->getOrdinals());
     }
 
-    public function testGetOrdinalsIntDoesNotEffectIteratorPosition()
-    {
-        $set = new EnumSet(EnumBasic::class);
-        $set->attach(EnumBasic::ONE);
-        $set->attach(EnumBasic::TWO);
-        $set->next();
-
-        $set->getOrdinals();
-        $this->assertSame(EnumBasic::TWO, $set->current()->getValue());
-    }
-
-    public function testGetOrdinalsBinDoesNotEffectIteratorPosition()
-    {
-        $set = new EnumSet(Enum66::class);
-        $set->attach(Enum66::ONE);
-        $set->attach(Enum66::TWO);
-        $set->next();
-
-        $set->getOrdinals();
-        $this->assertSame(Enum66::TWO, $set->current()->getValue());
-    }
-
     public function testGetEnumerators()
     {
         $set = new EnumSet(EnumBasic::class);
@@ -705,17 +554,6 @@ class EnumSetTest extends TestCase
         }
 
         $this->assertSame(EnumBasic::getEnumerators(), $set->getEnumerators());
-    }
-
-    public function testGetEnumeratorsDoesNotEffectIteratorPosition()
-    {
-        $set = new EnumSet(EnumBasic::class);
-        $set->attach(EnumBasic::ONE);
-        $set->attach(EnumBasic::TWO);
-        $set->next();
-
-        $set->getEnumerators();
-        $this->assertSame(EnumBasic::TWO, $set->current()->getValue());
     }
 
     public function testGetValues()
@@ -730,17 +568,6 @@ class EnumSetTest extends TestCase
         $this->assertSame(array_values(EnumBasic::getConstants()), $set->getValues());
     }
 
-    public function testGetValuesDoesNotEffectIteratorPosition()
-    {
-        $set = new EnumSet(EnumBasic::class);
-        $set->attach(EnumBasic::ONE);
-        $set->attach(EnumBasic::TWO);
-        $set->next();
-
-        $set->getValues();
-        $this->assertSame(EnumBasic::TWO, $set->current()->getValue());
-    }
-
     public function testGetNames()
     {
         $set = new EnumSet(EnumBasic::class);
@@ -751,17 +578,6 @@ class EnumSetTest extends TestCase
         }
 
         $this->assertSame(array_keys(EnumBasic::getConstants()), $set->getNames());
-    }
-
-    public function testGetNamesDoesNotEffectIteratorPosition()
-    {
-        $set = new EnumSet(EnumBasic::class);
-        $set->attach(EnumBasic::ONE);
-        $set->attach(EnumBasic::TWO);
-        $set->next();
-
-        $set->getNames();
-        $this->assertSame(EnumBasic::TWO, $set->current()->getValue());
     }
 
     public function testUnion()


### PR DESCRIPTION
This opens possibility to have two different iterators of the same `EnumSet` object.
It could also reduce some memory on instantiating an `EnumSet` by the cost of having to instantiate the iterator separately if needed.

@prolic ping