### PR TITLE
Immutable EnumSet

### DIFF
--- a/bench/EnumSet32Bench.php
+++ b/bench/EnumSet32Bench.php
@@ -48,38 +48,103 @@ class EnumSet32Bench
         $this->enumerators = Enum32::getEnumerators();
 
         $this->emptySet = new EnumSet(Enum32::class);
-        $this->fullSet  = new EnumSet(Enum32::class);
-        foreach ($this->enumerators as $enumerator) {
-            $this->fullSet->attach($enumerator);
-        }
+        $this->fullSet  = new EnumSet(Enum32::class, $this->enumerators);
     }
 
     public function benchAttachEnumerator()
     {
         foreach ($this->enumerators as $enumerator) {
-            $this->emptySet->attach($enumerator);
+            $this->emptySet->attachEnumerator($enumerator);
+        }
+    }
+
+    public function benchWithEnumerator()
+    {
+        foreach ($this->enumerators as $enumerator) {
+            $this->emptySet->withEnumerator($enumerator);
+        }
+    }
+
+    public function benchAttachEnumerators()
+    {
+        $this->emptySet->withEnumerators($this->enumerators);
+    }
+
+    public function benchWithEnumerators()
+    {
+        $this->emptySet->attachEnumerators($this->enumerators);
+    }
+
+    public function benchWithValue()
+    {
+        foreach ($this->values as $value) {
+            $this->emptySet->withEnumerator($value);
         }
     }
 
     public function benchAttachValue()
     {
         foreach ($this->values as $value) {
-            $this->emptySet->attach($value);
+            $this->emptySet->attachEnumerator($value);
         }
+    }
+
+    public function benchAttachValues()
+    {
+        $this->emptySet->attachEnumerators($this->values);
+    }
+
+    public function benchWithValues()
+    {
+        $this->emptySet->withEnumerators($this->values);
     }
 
     public function benchDetachEnumerator()
     {
         foreach ($this->enumerators as $enumerator) {
-            $this->fullSet->detach($enumerator);
+            $this->fullSet->detachEnumerator($enumerator);
         }
+    }
+
+    public function benchWithoutEnumerator()
+    {
+        foreach ($this->enumerators as $enumerator) {
+            $this->fullSet->withoutEnumerator($enumerator);
+        }
+    }
+
+    public function benchDetachEnumerators()
+    {
+        $this->fullSet->detachEnumerators($this->enumerators);
+    }
+
+    public function benchWithoutEnumerators()
+    {
+        $this->fullSet->withoutEnumerators($this->enumerators);
     }
 
     public function benchDetachValue()
     {
         foreach ($this->values as $value) {
-            $this->fullSet->detach($value);
+            $this->fullSet->detachEnumerator($value);
         }
+    }
+
+    public function benchWithoutValue()
+    {
+        foreach ($this->values as $value) {
+            $this->fullSet->withoutEnumerator($value);
+        }
+    }
+
+    public function benchDetachValues()
+    {
+        $this->fullSet->detachEnumerators($this->values);
+    }
+
+    public function benchWithoutValues()
+    {
+        $this->fullSet->withoutEnumerators($this->values);
     }
 
     public function benchContainsEnumerator()
@@ -135,24 +200,44 @@ class EnumSet32Bench
         $this->fullSet->isSuperset($this->fullSet);
     }
 
-    public function benchUnion()
+    public function benchSetUnion()
     {
-        $this->fullSet->union($this->emptySet);
+        $this->fullSet->setUnion($this->emptySet);
     }
 
-    public function benchIntersect()
+    public function benchWithUnion()
     {
-        $this->fullSet->intersect($this->emptySet);
+        $this->fullSet->withUnion($this->emptySet);
     }
 
-    public function benchDiff()
+    public function benchSetIntersect()
     {
-        $this->fullSet->diff($this->emptySet);
+        $this->fullSet->setIntersect($this->emptySet);
     }
 
-    public function benchSymDiff()
+    public function benchWithIntersect()
     {
-        $this->fullSet->symDiff($this->emptySet);
+        $this->fullSet->withIntersect($this->emptySet);
+    }
+
+    public function benchSetDiff()
+    {
+        $this->fullSet->setDiff($this->emptySet);
+    }
+
+    public function benchWithDiff()
+    {
+        $this->fullSet->withDiff($this->emptySet);
+    }
+
+    public function benchSetSymDiff()
+    {
+        $this->fullSet->setSymDiff($this->emptySet);
+    }
+
+    public function benchWithSymDiff()
+    {
+        $this->fullSet->withSymDiff($this->emptySet);
     }
 
     public function benchGetOrdinalsFull()

--- a/bench/EnumSet66Bench.php
+++ b/bench/EnumSet66Bench.php
@@ -48,38 +48,103 @@ class EnumSet66Bench
         $this->enumerators = Enum66::getEnumerators();
 
         $this->emptySet = new EnumSet(Enum66::class);
-        $this->fullSet  = new EnumSet(Enum66::class);
-        foreach ($this->enumerators as $enumerator) {
-            $this->fullSet->attach($enumerator);
-        }
+        $this->fullSet  = new EnumSet(Enum66::class, $this->enumerators);
     }
 
     public function benchAttachEnumerator()
     {
         foreach ($this->enumerators as $enumerator) {
-            $this->emptySet->attach($enumerator);
+            $this->emptySet->attachEnumerator($enumerator);
         }
+    }
+
+    public function benchWithEnumerator()
+    {
+        foreach ($this->enumerators as $enumerator) {
+            $this->emptySet->withEnumerator($enumerator);
+        }
+    }
+
+    public function benchAttachEnumerators()
+    {
+        $this->emptySet->attachEnumerators($this->enumerators);
+    }
+
+    public function benchWithEnumerators()
+    {
+        $this->emptySet->withEnumerators($this->enumerators);
     }
 
     public function benchAttachValue()
     {
         foreach ($this->values as $value) {
-            $this->emptySet->attach($value);
+            $this->emptySet->attachEnumerator($value);
         }
+    }
+
+    public function benchWithValue()
+    {
+        foreach ($this->values as $value) {
+            $this->emptySet->withEnumerator($value);
+        }
+    }
+
+    public function benchAttachValues()
+    {
+        $this->emptySet->attachEnumerators($this->values);
+    }
+
+    public function benchWithValues()
+    {
+        $this->emptySet->withEnumerators($this->values);
     }
 
     public function benchDetachEnumerator()
     {
         foreach ($this->enumerators as $enumerator) {
-            $this->emptySet->detach($enumerator);
+            $this->emptySet->detachEnumerator($enumerator);
         }
+    }
+
+    public function benchWithoutEnumerator()
+    {
+        foreach ($this->enumerators as $enumerator) {
+            $this->emptySet->withoutEnumerator($enumerator);
+        }
+    }
+
+    public function benchDetachEnumerators()
+    {
+        $this->emptySet->detachEnumerators($this->enumerators);
+    }
+
+    public function benchWithoutEnumerators()
+    {
+        $this->emptySet->withoutEnumerators($this->enumerators);
     }
 
     public function benchDetachValue()
     {
         foreach ($this->values as $value) {
-            $this->emptySet->detach($value);
+            $this->emptySet->detachEnumerator($value);
         }
+    }
+
+    public function benchWithoutValue()
+    {
+        foreach ($this->values as $value) {
+            $this->emptySet->withoutEnumerator($value);
+        }
+    }
+
+    public function benchDetachValues()
+    {
+        $this->emptySet->detachEnumerators($this->values);
+    }
+
+    public function benchWithoutValues()
+    {
+        $this->emptySet->withoutEnumerators($this->values);
     }
 
     public function benchContainsEnumerator()
@@ -135,24 +200,44 @@ class EnumSet66Bench
         $this->fullSet->isSuperset($this->fullSet);
     }
 
-    public function benchUnion()
+    public function benchSetUnion()
     {
-        $this->fullSet->union($this->emptySet);
+        $this->fullSet->setUnion($this->emptySet);
     }
 
-    public function benchIntersect()
+    public function benchWithUnion()
     {
-        $this->fullSet->intersect($this->emptySet);
+        $this->fullSet->withUnion($this->emptySet);
     }
 
-    public function benchDiff()
+    public function benchSetIntersect()
     {
-        $this->fullSet->diff($this->emptySet);
+        $this->fullSet->setIntersect($this->emptySet);
     }
 
-    public function benchSymDiff()
+    public function benchWithIntersect()
     {
-        $this->fullSet->symDiff($this->emptySet);
+        $this->fullSet->withIntersect($this->emptySet);
+    }
+
+    public function benchSetDiff()
+    {
+        $this->fullSet->setDiff($this->emptySet);
+    }
+
+    public function benchWithDiff()
+    {
+        $this->fullSet->withDiff($this->emptySet);
+    }
+
+    public function benchSetSymDiff()
+    {
+        $this->fullSet->setSymDiff($this->emptySet);
+    }
+
+    public function benchWithSymDiff()
+    {
+        $this->fullSet->withSymDiff($this->emptySet);
     }
 
     public function benchGetOrdinalsFull()

--- a/tests/MabeEnumTest/EnumSetIteratorTest.php
+++ b/tests/MabeEnumTest/EnumSetIteratorTest.php
@@ -34,9 +34,9 @@ class EnumSetIteratorTest extends TestCase
     public function testIterateOrdered()
     {
         $set = new EnumSet(EnumBasic::class);
-        $set->attach(EnumBasic::FOUR);
-        $set->attach(EnumBasic::TWO);
-        $set->attach(EnumBasic::SEVEN);
+        $set = $set->withEnumerator(EnumBasic::FOUR);
+        $set = $set->withEnumerator(EnumBasic::TWO);
+        $set = $set->withEnumerator(EnumBasic::SEVEN);
 
         $this->assertSame([
             1 => EnumBasic::TWO(),
@@ -48,8 +48,8 @@ class EnumSetIteratorTest extends TestCase
     public function testMultipleIterators()
     {
         $set = new EnumSet(EnumBasic::class);
-        $set->attach(EnumBasic::ONE);
-        $set->attach(EnumBasic::TWO);
+        $set = $set->withEnumerator(EnumBasic::ONE);
+        $set = $set->withEnumerator(EnumBasic::TWO);
 
         $it1 = $set->getIterator();
         $it2 = $set->getIterator();
@@ -62,7 +62,7 @@ class EnumSetIteratorTest extends TestCase
     public function testStartAtFirstValidPosition()
     {
         $set = new EnumSet(EnumBasic::class);
-        $set->attach(EnumBasic::SEVEN);
+        $set = $set->withEnumerator(EnumBasic::SEVEN);
 
         $it = $set->getIterator();
         $this->assertSame(EnumBasic::SEVEN(), $it->current());
@@ -88,7 +88,7 @@ class EnumSetIteratorTest extends TestCase
         $set   = new EnumSet($enumeration);
         $count = count($enumeration::getConstants());
         $last  = $enumeration::byOrdinal($count - 1);
-        $set->attach($last);
+        $set   = $set->withEnumerator($last);
 
         $it = $set->getIterator();
         $this->assertTrue($it->valid());


### PR DESCRIPTION
Based on #108 

* implements `EnumSet` as immutable
* `attach(): void` -> `withEnumerator(): self`
* `detach(): void` -> `withoutEnumerator(): self`
* `setBit(): void` -> `withBit(): self`
* `setBinaryBitset[Le|Be](): void` -> `withBinaryBitset[Le|Be](): self`

PS 1: I still want to make some benchmarks for comparison
PS 2: This make sense only if we make `EnumMap` immutable too

@prolic ping