### PR TITLE
Less type hints

### DIFF
--- a/bench/EnumBench.php
+++ b/bench/EnumBench.php
@@ -115,6 +115,11 @@ class EnumBench
         Enum66::getConstants();
     }
 
+    public function benchGetConstants()
+    {
+        Enum66::getConstants();
+    }
+
     public function benchGetValues()
     {
         Enum66::getValues();
@@ -142,14 +147,6 @@ class EnumBench
         }
     }
 
-    public function benchByValueAndInitialize()
-    {
-        foreach ($this->values as $value) {
-            $this->destructEnumerations();
-            Enum66::byValue($value);
-        }
-    }
-
     public function benchByValueAndInstantiate()
     {
         $this->destructEnumerationInstances();
@@ -165,14 +162,6 @@ class EnumBench
         }
     }
 
-    public function benchByNameAndInitialize()
-    {
-        foreach ($this->names as $name) {
-            $this->destructEnumerations();
-            Enum66::byName($name);
-        }
-    }
-
     public function benchByNameAndInstantiate()
     {
         $this->destructEnumerationInstances();
@@ -184,14 +173,6 @@ class EnumBench
     public function benchByOrdinal()
     {
         foreach ($this->ordinals as $ord) {
-            Enum66::byOrdinal($ord);
-        }
-    }
-
-    public function benchByOrdinalAndInitialize()
-    {
-        foreach ($this->ordinals as $ord) {
-            $this->destructEnumerations();
             Enum66::byOrdinal($ord);
         }
     }

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -58,7 +58,7 @@ abstract class Enum
      * @param null|bool|int|float|string|array $value   The value of the enumerator
      * @param int|null                         $ordinal The ordinal number of the enumerator
      */
-    final private function __construct($value, int $ordinal = null)
+    final private function __construct($value, $ordinal = null)
     {
         $this->value   = $value;
         $this->ordinal = $ordinal;
@@ -117,7 +117,7 @@ abstract class Enum
      *
      * @return string
      */
-    final public function getName(): string
+    final public function getName()
     {
         return self::$names[static::class][$this->ordinal ?: $this->getOrdinal()];
     }
@@ -127,7 +127,7 @@ abstract class Enum
      *
      * @return int
      */
-    final public function getOrdinal(): int
+    final public function getOrdinal()
     {
         if ($this->ordinal === null) {
             $ordinal = 0;
@@ -151,7 +151,7 @@ abstract class Enum
      * @param static|null|bool|int|float|string|array $enumerator An enumerator object or value
      * @return bool
      */
-    final public function is($enumerator): bool
+    final public function is($enumerator)
     {
         return $this === $enumerator || $this->value === $enumerator
 
@@ -170,7 +170,7 @@ abstract class Enum
      * @throws InvalidArgumentException On an unknwon or invalid value
      * @throws LogicException           On ambiguous constant values
      */
-    final public static function get($enumerator): self
+    final public static function get($enumerator)
     {
         if ($enumerator instanceof static && \get_class($enumerator) === static::class) {
             return $enumerator;
@@ -187,7 +187,7 @@ abstract class Enum
      * @throws InvalidArgumentException On an unknwon or invalid value
      * @throws LogicException           On ambiguous constant values
      */
-    final public static function byValue($value): self
+    final public static function byValue($value)
     {
         if (!isset(self::$constants[static::class])) {
             self::detectConstants(static::class);
@@ -219,7 +219,7 @@ abstract class Enum
      * @throws InvalidArgumentException On an invalid or unknown name
      * @throws LogicException           On ambiguous values
      */
-    final public static function byName(string $name): self
+    final public static function byName(string $name)
     {
         if (isset(self::$instances[static::class][$name])) {
             return self::$instances[static::class][$name];
@@ -241,7 +241,7 @@ abstract class Enum
      * @throws InvalidArgumentException On an invalid ordinal number
      * @throws LogicException           On ambiguous values
      */
-    final public static function byOrdinal(int $ordinal): self
+    final public static function byOrdinal(int $ordinal)
     {
         if (!isset(self::$names[static::class])) {
             self::detectConstants(static::class);
@@ -268,7 +268,7 @@ abstract class Enum
      *
      * @return static[]
      */
-    final public static function getEnumerators(): array
+    final public static function getEnumerators()
     {
         if (!isset(self::$names[static::class])) {
             self::detectConstants(static::class);
@@ -281,7 +281,7 @@ abstract class Enum
      *
      * @return mixed[]
      */
-    final public static function getValues(): array
+    final public static function getValues()
     {
         return \array_values(self::detectConstants(static::class));
     }
@@ -291,7 +291,7 @@ abstract class Enum
      *
      * @return string[]
      */
-    final public static function getNames(): array
+    final public static function getNames()
     {
         if (!isset(self::$names[static::class])) {
             self::detectConstants(static::class);
@@ -304,7 +304,7 @@ abstract class Enum
      *
      * @return int[]
      */
-    final public static function getOrdinals(): array
+    final public static function getOrdinals()
     {
         $count = \count(self::detectConstants(static::class));
         return $count ? \range(0, $count - 1) : [];
@@ -316,7 +316,7 @@ abstract class Enum
      * @return array
      * @throws LogicException On ambiguous constant values
      */
-    final public static function getConstants(): array
+    final public static function getConstants()
     {
         return self::detectConstants(static::class);
     }
@@ -327,7 +327,7 @@ abstract class Enum
      * @param static|null|bool|int|float|string|array $enumerator
      * @return bool
      */
-    final public static function has($enumerator): bool
+    final public static function has($enumerator)
     {
         return ($enumerator instanceof static && \get_class($enumerator) === static::class)
             || static::hasValue($enumerator);
@@ -339,7 +339,7 @@ abstract class Enum
      * @param null|bool|int|float|string|array $value
      * @return bool
      */
-    final public static function hasValue($value): bool
+    final public static function hasValue($value)
     {
         $constants = self::detectConstants(static::class);
         return \in_array($value, $constants, true);
@@ -351,7 +351,7 @@ abstract class Enum
      * @param string $name
      * @return bool
      */
-    final public static function hasName(string $name): bool
+    final public static function hasName(string $name)
     {
         return \defined("static::{$name}");
     }
@@ -362,7 +362,7 @@ abstract class Enum
      * @param string $class
      * @return array
      */
-    private static function detectConstants(string $class): array
+    private static function detectConstants($class)
     {
         if (!isset(self::$constants[$class])) {
             $reflection = new ReflectionClass($class);
@@ -397,7 +397,7 @@ abstract class Enum
      * @param array $constants
      * @return bool
      */
-    private static function noAmbiguousValues(array $constants): bool
+    private static function noAmbiguousValues($constants)
     {
         foreach ($constants as $value) {
             $names = \array_keys($constants, $value, true);
@@ -421,7 +421,7 @@ abstract class Enum
      * @throws InvalidArgumentException On an invalid or unknown name
      * @throws LogicException           On ambiguous constant values
      */
-    final public static function __callStatic(string $method, array $args): self
+    final public static function __callStatic(string $method, array $args)
     {
         return self::byName($method);
     }

--- a/src/EnumMap.php
+++ b/src/EnumMap.php
@@ -95,7 +95,7 @@ class EnumMap implements ArrayAccess, Countable, SeekableIterator
      * @param bool $strict Use strict type comparison
      * @return Enum|null The found key or NULL
      */
-    public function search($value, bool $strict = false): ?Enum
+    public function search($value, bool $strict = false)
     {
         $ord = \array_search($value, $this->map, $strict);
         if ($ord !== false) {

--- a/src/EnumSerializableTrait.php
+++ b/src/EnumSerializableTrait.php
@@ -42,10 +42,11 @@ trait EnumSerializableTrait
      * Unserializes a given serialized value and push it into the current instance
      * This will be called automatically on `unserialize()` if the enumeration implements the `Serializable` interface
      * @param string $serialized
+     * @return void
      * @throws RuntimeException On an unknown or invalid value
      * @throws LogicException   On changing numeration value by calling this directly
      */
-    public function unserialize($serialized)
+    public function unserialize($serialized): void
     {
         $value     = \unserialize($serialized);
         $constants = self::getConstants();

--- a/src/EnumSet.php
+++ b/src/EnumSet.php
@@ -156,7 +156,7 @@ class EnumSet implements IteratorAggregate, Countable
      * @see getIterator()
      * @see goGetIteratorInt()
      */
-    private function doGetIteratorBin(): Iterator
+    private function doGetIteratorBin()
     {
         $bitset   = $this->bitset;
         $byteLen  = \strlen($bitset);
@@ -185,7 +185,7 @@ class EnumSet implements IteratorAggregate, Countable
      * @see getIterator()
      * @see doGetIteratorBin()
      */
-    private function doGetIteratorInt(): Iterator
+    private function doGetIteratorInt()
     {
         $count  = $this->enumerationCount;
         $bitset = $this->bitset;
@@ -219,7 +219,7 @@ class EnumSet implements IteratorAggregate, Countable
      * @see count()
      * @see doCountInt()
      */
-    private function doCountBin(): int
+    private function doCountBin()
     {
         $count   = 0;
         $bitset  = $this->bitset;
@@ -252,7 +252,7 @@ class EnumSet implements IteratorAggregate, Countable
      * @see count()
      * @see doCountBin()
      */
-    private function doCountInt(): int
+    private function doCountInt()
     {
         $count  = 0;
         $bitset = $this->bitset;
@@ -325,10 +325,10 @@ class EnumSet implements IteratorAggregate, Countable
      * Produce a new set with enumerators from both this and other (this | other)
      *
      * @param EnumSet $other EnumSet of the same enumeration to produce the union
-     * @return EnumSet
+     * @return static
      * @throws InvalidArgumentException If $other doesn't match the enumeration
      */
-    public function union(EnumSet $other): EnumSet
+    public function union(EnumSet $other): self
     {
         if ($this->enumeration !== $other->enumeration) {
             throw new InvalidArgumentException(\sprintf(
@@ -346,10 +346,10 @@ class EnumSet implements IteratorAggregate, Countable
      * Produce a new set with enumerators common to both this and other (this & other)
      *
      * @param EnumSet $other EnumSet of the same enumeration to produce the intersect
-     * @return EnumSet
+     * @return static
      * @throws InvalidArgumentException If $other doesn't match the enumeration
      */
-    public function intersect(EnumSet $other): EnumSet
+    public function intersect(EnumSet $other): self
     {
         if ($this->enumeration !== $other->enumeration) {
             throw new InvalidArgumentException(\sprintf(
@@ -367,10 +367,10 @@ class EnumSet implements IteratorAggregate, Countable
      * Produce a new set with enumerators in this but not in other (this - other)
      *
      * @param EnumSet $other EnumSet of the same enumeration to produce the diff
-     * @return EnumSet
+     * @return static
      * @throws InvalidArgumentException If $other doesn't match the enumeration
      */
-    public function diff(EnumSet $other): EnumSet
+    public function diff(EnumSet $other): self
     {
         if ($this->enumeration !== $other->enumeration) {
             throw new InvalidArgumentException(\sprintf(
@@ -388,10 +388,10 @@ class EnumSet implements IteratorAggregate, Countable
      * Produce a new set with enumerators in either this and other but not in both (this ^ other)
      *
      * @param EnumSet $other EnumSet of the same enumeration to produce the symmetric difference
-     * @return EnumSet
+     * @return static
      * @throws InvalidArgumentException If $other doesn't match the enumeration
      */
-    public function symDiff(EnumSet $other): EnumSet
+    public function symDiff(EnumSet $other): self
     {
         if ($this->enumeration !== $other->enumeration) {
             throw new InvalidArgumentException(\sprintf(
@@ -425,7 +425,7 @@ class EnumSet implements IteratorAggregate, Countable
      * @see getOrdinals()
      * @see goGetOrdinalsInt()
      */
-    private function doGetOrdinalsBin(): array
+    private function doGetOrdinalsBin()
     {
         $ordinals = [];
         $bitset   = $this->bitset;
@@ -455,7 +455,7 @@ class EnumSet implements IteratorAggregate, Countable
      * @see getOrdinals()
      * @see doGetOrdinalsBin()
      */
-    private function doGetOrdinalsInt(): array
+    private function doGetOrdinalsInt()
     {
         $ordinals = [];
         $count    = $this->enumerationCount;
@@ -531,7 +531,7 @@ class EnumSet implements IteratorAggregate, Countable
      * @see getBinaryBitsetLe()
      * @see doGetBinaryBitsetLeInt()
      */
-    private function doGetBinaryBitsetLeBin(): string
+    private function doGetBinaryBitsetLeBin()
     {
         return $this->bitset;
     }
@@ -545,7 +545,7 @@ class EnumSet implements IteratorAggregate, Countable
      * @see getBinaryBitsetLe()
      * @see doGetBinaryBitsetLeBin()
      */
-    private function doGetBinaryBitsetLeInt(): string
+    private function doGetBinaryBitsetLeInt()
     {
         $bin = \pack(\PHP_INT_SIZE === 8 ? 'P' : 'V', $this->bitset);
         return \substr($bin, 0, (int)\ceil($this->enumerationCount / 8));
@@ -578,7 +578,7 @@ class EnumSet implements IteratorAggregate, Countable
      * @see setBinaryBitsetLeBin()
      * @see doSetBinaryBitsetLeInt()
      */
-    private function doSetBinaryBitsetLeBin(string $bitset): void
+    private function doSetBinaryBitsetLeBin($bitset): void
     {
         $size   = \strlen($this->bitset);
         $sizeIn = \strlen($bitset);
@@ -619,7 +619,7 @@ class EnumSet implements IteratorAggregate, Countable
      * @see setBinaryBitsetLeBin()
      * @see doSetBinaryBitsetLeBin()
      */
-    private function doSetBinaryBitsetLeInt(string $bitset): void
+    private function doSetBinaryBitsetLeInt($bitset): void
     {
         $len = \strlen($bitset);
         $int = 0;
@@ -692,7 +692,7 @@ class EnumSet implements IteratorAggregate, Countable
      * @see getBit()
      * @see doGetBitInt()
      */
-    private function doGetBitBin(int $ordinal): bool
+    private function doGetBitBin($ordinal)
     {
         return (\ord($this->bitset[(int) ($ordinal / 8)]) & 1 << ($ordinal % 8)) !== 0;
     }
@@ -707,7 +707,7 @@ class EnumSet implements IteratorAggregate, Countable
      * @see getBit()
      * @see doGetBitBin()
      */
-    private function doGetBitInt(int $ordinal): bool
+    private function doGetBitInt($ordinal)
     {
         return (bool)($this->bitset & (1 << $ordinal));
     }
@@ -747,7 +747,7 @@ class EnumSet implements IteratorAggregate, Countable
      * @see setBit()
      * @see doSetBitInt()
      */
-    private function doSetBitBin(int $ordinal): void
+    private function doSetBitBin($ordinal): void
     {
         $byte = (int) ($ordinal / 8);
         $this->bitset[$byte] = $this->bitset[$byte] | \chr(1 << ($ordinal % 8));
@@ -763,7 +763,7 @@ class EnumSet implements IteratorAggregate, Countable
      * @see setBit()
      * @see doSetBitBin()
      */
-    private function doSetBitInt(int $ordinal): void
+    private function doSetBitInt($ordinal): void
     {
         $this->bitset = $this->bitset | (1 << $ordinal);
     }
@@ -778,7 +778,7 @@ class EnumSet implements IteratorAggregate, Countable
      * @see setBit()
      * @see doUnsetBitInt()
      */
-    private function doUnsetBitBin(int $ordinal): void
+    private function doUnsetBitBin($ordinal): void
     {
         $byte = (int) ($ordinal / 8);
         $this->bitset[$byte] = $this->bitset[$byte] & \chr(~(1 << ($ordinal % 8)));
@@ -794,7 +794,7 @@ class EnumSet implements IteratorAggregate, Countable
      * @see setBit()
      * @see doUnsetBitBin()
      */
-    private function doUnsetBitInt(int $ordinal): void
+    private function doUnsetBitInt($ordinal): void
     {
         $this->bitset = $this->bitset & ~(1 << $ordinal);
     }


### PR DESCRIPTION
Removed type-hints (except void) for private and final methods as this gives a small performance boost and this lib has enough tests to make sure it's working as expected.

Benchmark result:
```
+----------------+------------------------------+--------+--------+------+----------------+-------------------------+
| benchmark      | subject                      | groups | params | revs | tag:MAJOR:mean | tag:lessTypeHints_:mean |
+----------------+------------------------------+--------+--------+------+----------------+-------------------------+
| EnumSet66Bench | benchAttachEnumeratorOnEmpty |        | []     | 2000 | 30.783μs       | 28.493μs                |
| EnumSet66Bench | benchAttachValueOnEmpty      |        | []     | 2000 | 56.411μs       | 53.703μs                |
| EnumSet66Bench | benchAttachEnumeratorOnFull  |        | []     | 2000 | 30.597μs       | 28.442μs                |
| EnumSet66Bench | benchAttachValueOnFull       |        | []     | 2000 | 56.412μs       | 53.715μs                |
| EnumSet66Bench | benchDetachEnumeratorOnEmpty |        | []     | 2000 | 31.284μs       | 28.958μs                |
| EnumSet66Bench | benchDetachValueOnEmpty      |        | []     | 2000 | 57.008μs       | 54.199μs                |
| EnumSet66Bench | benchDetachEnumeratorOnFull  |        | []     | 2000 | 31.423μs       | 28.897μs                |
| EnumSet66Bench | benchDetachValueOnFull       |        | []     | 2000 | 56.693μs       | 54.084μs                |
| EnumSet66Bench | benchContainsEnumeratorTrue  |        | []     | 2000 | 29.876μs       | 26.986μs                |
| EnumSet66Bench | benchContainsValueTrue       |        | []     | 2000 | 53.853μs       | 51.888μs                |
| EnumSet66Bench | benchContainsEnumeratorFalse |        | []     | 2000 | 29.974μs       | 27.004μs                |
| EnumSet66Bench | benchContainsValueFalse      |        | []     | 2000 | 53.815μs       | 51.934μs                |
| EnumSet66Bench | benchIterateFull             |        | []     | 2000 | 35.096μs       | 35.396μs                |
| EnumSet66Bench | benchIterateEmpty            |        | []     | 2000 | 0.571μs        | 0.570μs                 |
| EnumSet66Bench | benchCountFull               |        | []     | 2000 | 1.424μs        | 1.419μs                 |
| EnumSet66Bench | benchCountEmpty              |        | []     | 2000 | 0.333μs        | 0.327μs                 |
| EnumSet66Bench | benchIsEqual                 |        | []     | 2000 | 0.121μs        | 0.121μs                 |
| EnumSet66Bench | benchIsSubset                |        | []     | 2000 | 0.121μs        | 0.122μs                 |
| EnumSet66Bench | benchIsSuperset              |        | []     | 2000 | 0.169μs        | 0.169μs                 |
| EnumSet66Bench | benchUnion                   |        | []     | 2000 | 0.235μs        | 0.234μs                 |
| EnumSet66Bench | benchIntersect               |        | []     | 2000 | 0.232μs        | 0.233μs                 |
| EnumSet66Bench | benchDiff                    |        | []     | 2000 | 0.252μs        | 0.253μs                 |
| EnumSet66Bench | benchSymDiff                 |        | []     | 2000 | 0.237μs        | 0.232μs                 |
| EnumSet66Bench | benchGetOrdinalsFull         |        | []     | 2000 | 3.244μs        | 3.225μs                 |
| EnumSet66Bench | benchGetOrdinalsEmpty        |        | []     | 2000 | 0.341μs        | 0.332μs                 |
| EnumSet66Bench | benchGetValues               |        | []     | 2000 | 31.070μs       | 30.359μs                |
| EnumSet66Bench | benchGetNames                |        | []     | 2000 | 34.719μs       | 33.899μs                |
| EnumSet66Bench | benchGetEnumerators          |        | []     | 2000 | 29.518μs       | 28.905μs                |
| EnumBench      | benchGetName                 |        | []     | 2500 | 4.936μs        | 4.672μs                 |
| EnumBench      | benchGetValue                |        | []     | 2500 | 2.230μs        | 2.225μs                 |
| EnumBench      | benchGetOrdinal              |        | []     | 2500 | 3.117μs        | 2.903μs                 |
| EnumBench      | benchIsByEnumerator          |        | []     | 2500 | 3.636μs        | 3.248μs                 |
| EnumBench      | benchIsByValue               |        | []     | 2500 | 5.654μs        | 5.317μs                 |
| EnumBench      | benchDetectConstants         |        | []     | 2500 | 62.596μs       | 62.511μs                |
| EnumBench      | benchGetValues               |        | []     | 2500 | 0.351μs        | 0.337μs                 |
| EnumBench      | benchGetNames                |        | []     | 2500 | 0.112μs        | 0.109μs                 |
| EnumBench      | benchGetOrdinals             |        | []     | 2500 | 0.375μs        | 0.361μs                 |
| EnumBench      | benchGetEnumerators          |        | []     | 2500 | 10.420μs       | 9.803μs                 |
| EnumBench      | benchByValue                 |        | []     | 2500 | 28.026μs       | 27.307μs                |
| EnumBench      | benchByValueAndInstantiate   |        | []     | 2500 | 43.467μs       | 42.259μs                |
| EnumBench      | benchByName                  |        | []     | 2500 | 9.103μs        | 8.594μs                 |
| EnumBench      | benchByNameAndInstantiate    |        | []     | 2500 | 46.501μs       | 44.991μs                |
| EnumBench      | benchByOrdinal               |        | []     | 2500 | 19.382μs       | 19.006μs                |
| EnumBench      | benchByOrdinalAndInstantiate |        | []     | 2500 | 32.429μs       | 31.050μs                |
| EnumBench      | benchGetByValues             |        | []     | 2500 | 31.381μs       | 30.165μs                |
| EnumBench      | benchGetByEnumerator         |        | []     | 2500 | 5.023μs        | 4.228μs                 |
| EnumBench      | benchGetByCallStatic         |        | []     | 2500 | 17.351μs       | 16.075μs                |
| EnumBench      | benchHasByEnumerator         |        | []     | 2500 | 4.769μs        | 4.381μs                 |
| EnumBench      | benchHasByValue              |        | []     | 2500 | 21.991μs       | 20.526μs                |
| EnumSet32Bench | benchAttachEnumerator        |        | []     | 2000 | 10.654μs       | 10.038μs                |
| EnumSet32Bench | benchAttachValue             |        | []     | 2000 | 20.892μs       | 20.133μs                |
| EnumSet32Bench | benchDetachEnumerator        |        | []     | 2000 | 10.599μs       | 9.874μs                 |
| EnumSet32Bench | benchDetachValue             |        | []     | 2000 | 20.963μs       | 20.021μs                |
| EnumSet32Bench | benchContainsEnumeratorTrue  |        | []     | 2000 | 11.757μs       | 10.581μs                |
| EnumSet32Bench | benchContainsEnumeratorFalse |        | []     | 2000 | 11.735μs       | 10.622μs                |
| EnumSet32Bench | benchContainsValueTrue       |        | []     | 2000 | 21.382μs       | 20.333μs                |
| EnumSet32Bench | benchContainsValueFalse      |        | []     | 2000 | 21.378μs       | 20.285μs                |
| EnumSet32Bench | benchIterateFull             |        | []     | 2000 | 15.943μs       | 15.688μs                |
| EnumSet32Bench | benchIterateEmpty            |        | []     | 2000 | 0.819μs        | 0.822μs                 |
| EnumSet32Bench | benchCountFull               |        | []     | 2000 | 0.615μs        | 0.608μs                 |
| EnumSet32Bench | benchCountEmpty              |        | []     | 2000 | 0.173μs        | 0.168μs                 |
| EnumSet32Bench | benchIsEqual                 |        | []     | 2000 | 0.146μs        | 0.146μs                 |
| EnumSet32Bench | benchIsSubset                |        | []     | 2000 | 0.146μs        | 0.147μs                 |
| EnumSet32Bench | benchIsSuperset              |        | []     | 2000 | 0.138μs        | 0.137μs                 |
| EnumSet32Bench | benchUnion                   |        | []     | 2000 | 0.200μs        | 0.200μs                 |
| EnumSet32Bench | benchIntersect               |        | []     | 2000 | 0.202μs        | 0.202μs                 |
| EnumSet32Bench | benchDiff                    |        | []     | 2000 | 0.202μs        | 0.202μs                 |
| EnumSet32Bench | benchSymDiff                 |        | []     | 2000 | 0.200μs        | 0.200μs                 |
| EnumSet32Bench | benchGetOrdinalsFull         |        | []     | 2000 | 1.130μs        | 1.104μs                 |
| EnumSet32Bench | benchGetOrdinalsEmpty        |        | []     | 2000 | 0.618μs        | 0.616μs                 |
| EnumSet32Bench | benchGetValues               |        | []     | 2000 | 14.744μs       | 14.449μs                |
| EnumSet32Bench | benchGetNames                |        | []     | 2000 | 16.518μs       | 16.075μs                |
| EnumSet32Bench | benchGetEnumerators          |        | []     | 2000 | 13.943μs       | 13.628μs                |
| EnumMapBench   | benchGetKeysEmpty            |        | []     | 2000 | 0.331μs        | 0.332μs                 |
| EnumMapBench   | benchGetKeysFull             |        | []     | 2000 | 20.713μs       | 20.154μs                |
| EnumMapBench   | benchGetValuesEmpty          |        | []     | 2000 | 0.069μs        | 0.071μs                 |
| EnumMapBench   | benchGetValuesFull           |        | []     | 2000 | 0.092μs        | 0.074μs                 |
| EnumMapBench   | benchSearchTypeJuggling      |        | []     | 2000 | 1.423μs        | 1.392μs                 |
| EnumMapBench   | benchSearchStrict            |        | []     | 2000 | 0.631μs        | 0.609μs                 |
| EnumMapBench   | benchOffsetSetEnumerator     |        | []     | 2000 | 19.698μs       | 18.527μs                |
| EnumMapBench   | benchOffsetSetValue          |        | []     | 2000 | 46.751μs       | 45.645μs                |
| EnumMapBench   | benchOffsetUnsetEnumerator   |        | []     | 2000 | 18.228μs       | 17.429μs                |
| EnumMapBench   | benchOffsetUnsetValue        |        | []     | 2000 | 45.000μs       | 43.630μs                |
| EnumMapBench   | benchOffsetExistsEnumerator  |        | []     | 2000 | 18.429μs       | 17.240μs                |
| EnumMapBench   | benchOffsetExistsValue       |        | []     | 2000 | 43.898μs       | 42.337μs                |
| EnumMapBench   | benchContainsEnumerator      |        | []     | 2000 | 19.135μs       | 17.688μs                |
| EnumMapBench   | benchContainsValue           |        | []     | 2000 | 45.518μs       | 44.062μs                |
| EnumMapBench   | benchIterateFull             |        | []     | 2000 | 51.135μs       | 51.590μs                |
| EnumMapBench   | benchIterateEmpty            |        | []     | 2000 | 0.194μs        | 0.193μs                 |
| EnumMapBench   | benchCountFull               |        | []     | 2000 | 0.063μs        | 0.063μs                 |
| EnumMapBench   | benchCountEmpty              |        | []     | 2000 | 0.061μs        | 0.061μs                 |
| EnumBench      | benchGetConstants            |        | []     | 2500 |                | 0.117μs                 |
+----------------+------------------------------+--------+--------+------+----------------+-------------------------+
```