### PR TITLE
Immutable EnumMap

### DIFF
--- a/src/EnumSet.php
+++ b/src/EnumSet.php
@@ -10,7 +10,7 @@ use Iterator;
 use IteratorAggregate;
 
 /**
- * A set of enumerators of the given enumeration (EnumSet<T>)
+ * A set of enumerators of the given enumeration (EnumSet<T extends Enum>)
  * based on an integer or binary bitset depending of given enumeration size.
  *
  * @copyright 2019 Marc Bennewitz


### PR DESCRIPTION
* added mutable methods
  * `add($enumerator, $value)`
  * `addIterable(iterable $map)`
  * `remove($enumerator)`
  * `removeIterable(iterable $enumerators)`
  * (These methods are added for consistent naming - see #120)
* added immutable methods
  * `with($enumerator, $value)`
  * `withIterable(iterable $map)`
  * `without($enumerator)`
  * `withoutIterable(iterable $enumerators)`
* other changes
  * added `get($enumerator)` : returns mapped data value or exception if missing
  * `offsetGet($enumerator)` now returns `null` if missing - this change is done to be consistent with `offsetExists($enumerator)` which gets called by `isset` and should follow this behavior