### PR TITLE
Fix call static

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -423,6 +423,6 @@ abstract class Enum
      */
     final public static function __callStatic(string $method, array $args)
     {
-        return self::byName($method);
+        return static::byName($method);
     }
 }

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -167,7 +167,7 @@ abstract class Enum
      *
      * @param static|null|bool|int|float|string|array $enumerator An enumerator object or value
      * @return static
-     * @throws InvalidArgumentException On an unknwon or invalid value
+     * @throws InvalidArgumentException On an unknown or invalid value
      * @throws LogicException           On ambiguous constant values
      */
     final public static function get($enumerator)
@@ -184,7 +184,7 @@ abstract class Enum
      *
      * @param null|bool|int|float|string|array $value Enumerator value
      * @return static
-     * @throws InvalidArgumentException On an unknwon or invalid value
+     * @throws InvalidArgumentException On an unknown or invalid value
      * @throws LogicException           On ambiguous constant values
      */
     final public static function byValue($value)

--- a/src/EnumSerializableTrait.php
+++ b/src/EnumSerializableTrait.php
@@ -24,7 +24,7 @@ trait EnumSerializableTrait
 {
     /**
      * The method will be defined by MabeEnum\Enum
-     * @return null|bool|int|float|string
+     * @return null|bool|int|float|string|array
      */
     abstract public function getValue();
 
@@ -49,7 +49,7 @@ trait EnumSerializableTrait
     public function unserialize($serialized): void
     {
         $value     = \unserialize($serialized);
-        $constants = self::getConstants();
+        $constants = static::getConstants();
         $name      = \array_search($value, $constants, true);
         if ($name === false) {
             $message = \is_scalar($value)

--- a/tests/MabeEnumTest/EnumSerializableTraitTest.php
+++ b/tests/MabeEnumTest/EnumSerializableTraitTest.php
@@ -4,6 +4,7 @@ namespace MabeEnumTest;
 
 use LogicException;
 use MabeEnum\Enum;
+use MabeEnumTest\TestAsset\ExtendedSerializableEnum;
 use MabeEnumTest\TestAsset\SerializableEnum;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
@@ -63,6 +64,18 @@ class EnumSerializableTraitTest extends TestCase
         $this->expectException(LogicException::class);
         $enum = SerializableEnum::get(SerializableEnum::INT);
         $enum->unserialize(serialize(SerializableEnum::STR));
+    }
+
+    public function testInheritence()
+    {
+        $enum = ExtendedSerializableEnum::EXTENDED();
+
+        $serialized = serialize($enum);
+        $this->assertInternalType('string', $serialized);
+
+        $unserialized = unserialize($serialized);
+        $this->assertInstanceOf(ExtendedSerializableEnum::class, $unserialized);
+        $this->assertSame($enum->getValue(), $unserialized->getValue());
     }
 
     /**

--- a/tests/MabeEnumTest/EnumTest.php
+++ b/tests/MabeEnumTest/EnumTest.php
@@ -101,10 +101,22 @@ class EnumTest extends TestCase
         ), EnumInheritance::getConstants());
 
         $enum = EnumInheritance::get(EnumInheritance::ONE);
+        $this->assertInstanceOf(EnumInheritance::class, $enum);
         $this->assertSame(EnumInheritance::ONE, $enum->getValue());
         $this->assertSame(0, $enum->getOrdinal());
 
         $enum = EnumInheritance::get(EnumInheritance::INHERITANCE);
+        $this->assertInstanceOf(EnumInheritance::class, $enum);
+        $this->assertSame(EnumInheritance::INHERITANCE, $enum->getValue());
+        $this->assertSame(17, $enum->getOrdinal());
+
+        $enum = EnumInheritance::ONE();
+        $this->assertInstanceOf(EnumInheritance::class, $enum);
+        $this->assertSame(EnumInheritance::ONE, $enum->getValue());
+        $this->assertSame(0, $enum->getOrdinal());
+
+        $enum = EnumInheritance::INHERITANCE();
+        $this->assertInstanceOf(EnumInheritance::class, $enum);
         $this->assertSame(EnumInheritance::INHERITANCE, $enum->getValue());
         $this->assertSame(17, $enum->getOrdinal());
     }

--- a/tests/MabeEnumTest/TestAsset/ExtendedSerializableEnum.php
+++ b/tests/MabeEnumTest/TestAsset/ExtendedSerializableEnum.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace MabeEnumTest\TestAsset;
+
+/**
+ * Extended serializable enumeration
+ *
+ * @link http://github.com/marc-mabe/php-enum for the canonical source repository
+ * @copyright Copyright (c) 2017 Marc Bennewitz
+ * @license http://github.com/marc-mabe/php-enum/blob/master/LICENSE.txt New BSD License
+ */
+class ExtendedSerializableEnum extends SerializableEnum
+{
+    const EXTENDED = 'extended';
+}


### PR DESCRIPTION
`Enum::__callStatic()` should call `static::byName()` instead of `self::byName()`.
Interestingly this never behaved wrongly but just because of a weird PHP behavior I have reported as a bug here https://bugs.php.net/bug.php?id=77985