### PR TITLE
Added purity markers for enumerables, improved type definitions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+/.github export-ignore
+/bench export-ignore
+/tests export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.travis.yml export-ignore
+phpbench.json export-ignore
+phpunit.xml.dist export-ignore
+psalm.xml export-ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,7 @@ script:
 
   # run benchmarks to make sure they are working fine
   - php vendor/bin/phpbench run --no-interaction --revs=1 --retry-threshold=100
+  - vendor/bin/psalm
 
 after_script:
   - if [ "${CODE_COVERAGE}" == "1" ]; then

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0",
-        "phpbench/phpbench": "^0.16.1"
+        "phpbench/phpbench": "^0.16.1",
+        "vimeo/psalm": "^3.10"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "ext-reflection": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0",
+        "phpunit/phpunit": "^7.0",
         "phpbench/phpbench": "^0.16.1"
     },
     "autoload": {

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<psalm
+    totallyTyped="true"
+    errorLevel="1"
+    resolveFromConfigFile="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+>
+    <projectFiles>
+        <directory name="tests/MabeEnumStaticAnalysis" />
+        <ignoreFiles>
+            <directory name="vendor" />
+        </ignoreFiles>
+    </projectFiles>
+</psalm>

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -14,6 +14,8 @@ use LogicException;
  * @copyright 2019 Marc Bennewitz
  * @license http://github.com/marc-mabe/php-enum/blob/master/LICENSE.txt New BSD License
  * @link http://github.com/marc-mabe/php-enum for the canonical source repository
+ *
+ * @psalm-immutable
  */
 abstract class Enum
 {
@@ -87,6 +89,8 @@ abstract class Enum
     /**
      * @throws LogicException Enums are not serializable
      *                        because instances are implemented as singletons
+     *
+     * @psalm-return never-return
      */
     final public function __sleep()
     {
@@ -96,6 +100,8 @@ abstract class Enum
     /**
      * @throws LogicException Enums are not serializable
      *                        because instances are implemented as singletons
+     *
+     * @psalm-return never-return
      */
     final public function __wakeup()
     {
@@ -116,6 +122,8 @@ abstract class Enum
      * Get the name of the enumerator
      *
      * @return string
+     *
+     * @psalm-return non-empty-string
      */
     final public function getName()
     {
@@ -170,6 +178,8 @@ abstract class Enum
      * @return static
      * @throws InvalidArgumentException On an unknown or invalid value
      * @throws LogicException           On ambiguous constant values
+     *
+     * @psalm-pure
      */
     final public static function get($enumerator)
     {
@@ -187,6 +197,8 @@ abstract class Enum
      * @return static
      * @throws InvalidArgumentException On an unknown or invalid value
      * @throws LogicException           On ambiguous constant values
+     *
+     * @psalm-pure
      */
     final public static function byValue($value)
     {
@@ -214,6 +226,8 @@ abstract class Enum
      * @return static
      * @throws InvalidArgumentException On an invalid or unknown name
      * @throws LogicException           On ambiguous values
+     *
+     * @psalm-pure
      */
     final public static function byName(string $name)
     {
@@ -241,6 +255,8 @@ abstract class Enum
      * @return static
      * @throws InvalidArgumentException On an invalid ordinal number
      * @throws LogicException           On ambiguous values
+     *
+     * @psalm-pure
      */
     final public static function byOrdinal(int $ordinal)
     {
@@ -263,6 +279,9 @@ abstract class Enum
      * Get a list of enumerator instances ordered by ordinal number
      *
      * @return static[]
+     *
+     * @psalm-return list<static>
+     * @psalm-pure
      */
     final public static function getEnumerators()
     {
@@ -276,6 +295,9 @@ abstract class Enum
      * Get a list of enumerator values ordered by ordinal number
      *
      * @return mixed[]
+     *
+     * @psalm-return list<null|bool|int|float|string|array>
+     * @psalm-pure
      */
     final public static function getValues()
     {
@@ -286,6 +308,9 @@ abstract class Enum
      * Get a list of enumerator names ordered by ordinal number
      *
      * @return string[]
+     *
+     * @psalm-return list<non-empty-string>
+     * @psalm-pure
      */
     final public static function getNames()
     {
@@ -294,11 +319,14 @@ abstract class Enum
         }
         return self::$names[static::class];
     }
-    
+
     /**
      * Get a list of enumerator ordinal numbers
      *
      * @return int[]
+     *
+     * @psalm-return list<int>
+     * @psalm-pure
      */
     final public static function getOrdinals()
     {
@@ -309,8 +337,11 @@ abstract class Enum
     /**
      * Get all available constants of the called class
      *
-     * @return array
+     * @return mixed[]
      * @throws LogicException On ambiguous constant values
+     *
+     * @psalm-return array<non-empty-string, null|bool|int|float|string|array>
+     * @psalm-pure
      */
     final public static function getConstants()
     {
@@ -361,9 +392,11 @@ abstract class Enum
 
     /**
      * Test if the given enumerator is part of this enumeration
-     * 
+     *
      * @param static|null|bool|int|float|string|array $enumerator
      * @return bool
+     *
+     * @psalm-pure
      */
     final public static function has($enumerator)
     {
@@ -376,6 +409,8 @@ abstract class Enum
      *
      * @param null|bool|int|float|string|array $value
      * @return bool
+     *
+     * @psalm-pure
      */
     final public static function hasValue($value)
     {
@@ -387,6 +422,8 @@ abstract class Enum
      *
      * @param string $name
      * @return bool
+     *
+     * @psalm-pure
      */
     final public static function hasName(string $name)
     {
@@ -404,6 +441,8 @@ abstract class Enum
      * @return static
      * @throws InvalidArgumentException On an invalid or unknown name
      * @throws LogicException           On ambiguous constant values
+     *
+     * @psalm-pure
      */
     final public static function __callStatic(string $method, array $args)
     {

--- a/tests/MabeEnumStaticAnalysis/DummyEnum.php
+++ b/tests/MabeEnumStaticAnalysis/DummyEnum.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MabeEnumStaticAnalysis;
+
+use MabeEnum\Enum;
+
+/** @psalm-immutable enums are immutable */
+final class DummyEnum extends Enum
+{
+    public const A = 'A_VALUE';
+    public const B = 'B_VALUE';
+
+    /** @psalm-pure */
+    public static function a(): self
+    {
+        return self::get(self::A);
+    }
+
+    /** @psalm-pure */
+    public static function b(): self
+    {
+        return self::get(self::B);
+    }
+}

--- a/tests/MabeEnumStaticAnalysis/EnumIsImmutable.php
+++ b/tests/MabeEnumStaticAnalysis/EnumIsImmutable.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MabeEnumStaticAnalysis;
+
+/**
+ * This is a static analysis fixture to verify that the API signature
+ * of an enum allows for pure operations. Almost all methods will seem to be
+ * redundant or trivial: that's normal, we're just verifying the
+ * transitivity of immutable type signatures.
+ *
+ * Please note that this does not guarantee that the internals of the enum
+ * library are pure/safe, but just that the declared API to the outside world
+ * is seen as immutable.
+ */
+final class EnumIsImmutable
+{
+    /** @psalm-pure */
+    public static function stringCastIsPure(): string
+    {
+        return DummyEnum::a()
+            ->__toString();
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @psalm-return never-return
+     */
+    public static function sleepIsPure(): void
+    {
+        DummyEnum::a()
+            ->__sleep();
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @psalm-return never-return
+     */
+    public static function wakeUpIsPure(): void
+    {
+        DummyEnum::a()
+            ->__wakeup();
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @psalm-return non-empty-string
+     */
+    public static function nameRetrievalIsPure(): string
+    {
+        return DummyEnum::a()
+            ->getName();
+    }
+
+    /**
+     * @return null|bool|int|float|string|array
+     *
+     * @psalm-pure
+     */
+    public static function valueRetrievalIsPure()
+    {
+        return DummyEnum::a()
+            ->getValue();
+    }
+
+    /** @psalm-pure */
+    public static function getIsPure(): DummyEnum
+    {
+        return DummyEnum::get(DummyEnum::A);
+    }
+
+    /** @psalm-pure */
+    public static function ordinalRetrievalIsPure(): int
+    {
+        return DummyEnum::a()
+            ->getOrdinal();
+    }
+
+    /** @psalm-pure */
+    public static function comparisonIsPure(): bool
+    {
+        return DummyEnum::a()->is(DummyEnum::b());
+    }
+
+    /** @psalm-pure */
+    public static function byValueIsPure(): DummyEnum
+    {
+        return DummyEnum::byValue('A_VALUE');
+    }
+
+    /** @psalm-pure */
+    public static function byNameIsPure(): DummyEnum
+    {
+        return DummyEnum::byValue('A');
+    }
+
+    /** @psalm-pure */
+    public static function byOrdinalIsPure(): DummyEnum
+    {
+        return DummyEnum::byOrdinal(1);
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @psalm-return list<DummyEnum>
+     */
+    public static function getEnumeratorsIsPure(): array
+    {
+        return DummyEnum::getEnumerators();
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @psalm-return list<null|bool|int|float|string|array>
+     */
+    public static function getValuesIsPure(): array
+    {
+        return DummyEnum::getValues();
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @psalm-return list<non-empty-string>
+     */
+    public static function getNamesIsPure(): array
+    {
+        return DummyEnum::getNames();
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @psalm-return list<int>
+     */
+    public static function getOrdinalsIsPure(): array
+    {
+        return DummyEnum::getOrdinals();
+    }
+
+    /** @psalm-pure */
+    public static function hasIsPure(): bool
+    {
+        return DummyEnum::has('a');
+    }
+
+    /** @psalm-pure */
+    public static function hasValueIsPure(): bool
+    {
+        return DummyEnum::hasValue('A_VALUE');
+    }
+
+    /** @psalm-pure */
+    public static function hasNameIsPure(): bool
+    {
+        return DummyEnum::hasName('A');
+    }
+
+    /** @psalm-pure */
+    public static function callStaticIsPure(): DummyEnum
+    {
+        return DummyEnum::__callStatic('a', []);
+    }
+}


### PR DESCRIPTION
This patch introduces a few improvements on the codebase:

 * adds `vimeo/psalm` minimal tests (not testing sources, just declared API)
 * adds `@psalm-pure` and `@psalm-immutable` to enumerable types, allowing usage of `Enum` in functionally pure (type-checked) contexts
 * add better type declarations where refinements are possible (such as `non-empty-string` vs `string`, where applicable)
 * removes some exported files from dist package (noticed because I wanted to exclude `psalm.xml` from exports)

I kept very conservative on type definitions: I wanted to restrict also on `::has()` and `::get()`, but that would introduce downstream issues, such as `::has($unknown)` failing due to missing upfront assertions.

Note: this is compatible with #138 too.