### PR TITLE
Added __debugInfo with human readable properties to EnumSet & EnumMap

### DIFF
--- a/src/EnumMap.php
+++ b/src/EnumMap.php
@@ -54,6 +54,22 @@ class EnumMap implements ArrayAccess, Countable, IteratorAggregate
         }
     }
 
+    /**
+     * Add virtual private property "__pairs" with a list of key-value-pairs
+     * to the result of var_dump.
+     *
+     * This helps debugging as internally the map is using the ordinal number.
+     *
+     * @return array<string, mixed>
+     */
+    public function __debugInfo(): array {
+        $dbg = (array)$this;
+        $dbg["\0" . self::class . "\0__pairs"] = array_map(function ($k, $v) {
+            return [$k, $v];
+        }, $this->getKeys(), $this->getValues());
+        return $dbg;
+    }
+
     /* write access (mutable) */
 
     /**

--- a/src/EnumSet.php
+++ b/src/EnumSet.php
@@ -107,6 +107,21 @@ class EnumSet implements IteratorAggregate, Countable
     }
 
     /**
+     * Add virtual private property "__enumerators" with a list of enumerator values set
+     * to the result of var_dump.
+     *
+     * This helps debugging as internally the enumerators of this EnumSet gets stored
+     * as either integer or binary bit-array.
+     *
+     * @return array<string, mixed>
+     */
+    public function __debugInfo() {
+        $dbg = (array)$this;
+        $dbg["\0" . self::class . "\0__enumerators"] = $this->getValues();
+        return $dbg;
+    }
+
+    /**
      * Get the classname of the enumeration
      * @return string
      */

--- a/tests/MabeEnumTest/EnumMapTest.php
+++ b/tests/MabeEnumTest/EnumMapTest.php
@@ -7,6 +7,7 @@ use MabeEnum\EnumMap;
 use MabeEnumTest\TestAsset\Enum32;
 use MabeEnumTest\TestAsset\EnumBasic;
 use MabeEnumTest\TestAsset\EnumInheritance;
+use MabeEnumTest\TestAsset\EnumMapExt;
 use PHPUnit\Framework\TestCase;
 use UnexpectedValueException;
 
@@ -486,6 +487,34 @@ class EnumMapTest extends TestCase
 
         $this->assertFalse($map1->isEmpty());
         $this->assertTrue($map2->isEmpty());
+    }
+
+    public function testDebugInfo()
+    {
+        $map = new EnumMapExt(EnumBasic::class);
+        foreach (EnumBasic::getEnumerators() as $i => $enumerator) {
+            $map->add($enumerator, $i);
+        }
+
+        $dbg = $map->__debugInfo();
+
+        $privateEnumMapPrefix = "\0" . EnumMap::class . "\0";
+        $privateEnumMapExtPrefix = "\0" . EnumMapExt::class . "\0";
+        $protectedEnumMapExtPrefix = "\0*\0";
+        $publicEnumMapExtPrefix = '';
+
+        // assert real properties still exists
+        $this->assertArrayHasKey("{$privateEnumMapPrefix}enumeration", $dbg);
+        $this->assertArrayHasKey("{$privateEnumMapPrefix}map", $dbg);
+        $this->assertArrayHasKey("{$privateEnumMapExtPrefix}priv", $dbg);
+        $this->assertArrayHasKey("{$protectedEnumMapExtPrefix}prot", $dbg);
+        $this->assertArrayHasKey("{$publicEnumMapExtPrefix}pub", $dbg);
+
+        // assert virtual private property __pairs
+        $this->assertArrayHasKey("{$privateEnumMapPrefix}__pairs", $dbg);
+        $this->assertSame(array_map(function ($k, $v) {
+            return [$k, $v];
+        }, $map->getKeys(), $map->getValues()), $dbg["{$privateEnumMapPrefix}__pairs"]);
     }
 
     /* deprecated */

--- a/tests/MabeEnumTest/EnumSetTest.php
+++ b/tests/MabeEnumTest/EnumSetTest.php
@@ -12,6 +12,7 @@ use MabeEnumTest\TestAsset\Enum32;
 use MabeEnumTest\TestAsset\Enum64;
 use MabeEnumTest\TestAsset\Enum65;
 use MabeEnumTest\TestAsset\Enum66;
+use MabeEnumTest\TestAsset\EnumSetExt;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -954,6 +955,28 @@ class EnumSetTest extends TestCase
 
         $this->expectException(InvalidArgumentException::class);
         $set1->setSymDiff($set2);
+    }
+
+    public function testDebugInfo()
+    {
+        $set = new EnumSetExt(EnumBasic::class, EnumBasic::getEnumerators());
+        $dbg = $set->__debugInfo();
+
+        $privateEnumSetPrefix = "\0" . EnumSet::class . "\0";
+        $privateEnumSetExtPrefix = "\0" . EnumSetExt::class . "\0";
+        $protectedEnumSetExtPrefix = "\0*\0";
+        $publicEnumSetExtPrefix = '';
+
+        // assert real properties still exists
+        $this->assertArrayHasKey("{$privateEnumSetPrefix}enumeration", $dbg);
+        $this->assertArrayHasKey("{$privateEnumSetPrefix}bitset", $dbg);
+        $this->assertArrayHasKey("{$privateEnumSetExtPrefix}priv", $dbg);
+        $this->assertArrayHasKey("{$protectedEnumSetExtPrefix}prot", $dbg);
+        $this->assertArrayHasKey("{$publicEnumSetExtPrefix}pub", $dbg);
+
+        // assert virtual private property __enumerators
+        $this->assertArrayHasKey("{$privateEnumSetPrefix}__enumerators", $dbg);
+        $this->assertSame(EnumBasic::getValues(), $dbg["{$privateEnumSetPrefix}__enumerators"]);
     }
 
     /* deprecated */

--- a/tests/MabeEnumTest/TestAsset/EnumMapExt.php
+++ b/tests/MabeEnumTest/TestAsset/EnumMapExt.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace MabeEnumTest\TestAsset;
+
+use MabeEnum\EnumMap;
+
+/**
+ * @link http://github.com/marc-mabe/php-enum for the canonical source repository
+ * @copyright Copyright (c) 2020 Marc Bennewitz
+ * @license http://github.com/marc-mabe/php-enum/blob/master/LICENSE.txt New BSD License
+ */
+class EnumMapExt extends EnumMap
+{
+    private $priv = 'private';
+    protected $prot = 'protected';
+    public $pub = 'public';
+}

--- a/tests/MabeEnumTest/TestAsset/EnumSetExt.php
+++ b/tests/MabeEnumTest/TestAsset/EnumSetExt.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace MabeEnumTest\TestAsset;
+
+use MabeEnum\EnumSet;
+
+/**
+ * @link http://github.com/marc-mabe/php-enum for the canonical source repository
+ * @copyright Copyright (c) 2020 Marc Bennewitz
+ * @license http://github.com/marc-mabe/php-enum/blob/master/LICENSE.txt New BSD License
+ */
+class EnumSetExt extends EnumSet
+{
+    private $priv = 'private';
+    protected $prot = 'protected';
+    public $pub = 'public';
+}


### PR DESCRIPTION
* EnumSet: Add virtual private property "__enumerators" with a list of enumerator values set to the result of var_dump. This helps debugging as internally the enumerators of this EnumSet gets stored as either integer or binary bit-array.

* EnumMap: Add virtual private property "__pairs" with a list of key-value-pairs to the result of var_dump. This helps debugging as internally the map is using the ordinal number.