### PR TITLE
final modifier for private method is no longer allowed in PHP8

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -81,7 +81,7 @@ abstract class Enum
      * @throws LogicException Enums are not cloneable
      *                        because instances are implemented as singletons
      */
-    private function __clone()
+    final protected function __clone()
     {
         throw new LogicException('Enums are not cloneable');
     }

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -60,7 +60,7 @@ abstract class Enum
      * @param null|bool|int|float|string|array<mixed> $value   The value of the enumerator
      * @param int|null                                $ordinal The ordinal number of the enumerator
      */
-    final private function __construct($value, $ordinal = null)
+    private function __construct($value, $ordinal = null)
     {
         $this->value   = $value;
         $this->ordinal = $ordinal;
@@ -81,7 +81,7 @@ abstract class Enum
      * @throws LogicException Enums are not cloneable
      *                        because instances are implemented as singletons
      */
-    final private function __clone()
+    private function __clone()
     {
         throw new LogicException('Enums are not cloneable');
     }

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -60,7 +60,7 @@ abstract class Enum
      * @param null|bool|int|float|string|array<mixed> $value   The value of the enumerator
      * @param int|null                                $ordinal The ordinal number of the enumerator
      */
-    private function __construct($value, $ordinal = null)
+    final private function __construct($value, $ordinal = null)
     {
         $this->value   = $value;
         $this->ordinal = $ordinal;

--- a/tests/MabeEnumTest/EnumTest.php
+++ b/tests/MabeEnumTest/EnumTest.php
@@ -377,7 +377,6 @@ class EnumTest extends TestCase
         $reflectionClass  = new ReflectionClass($enum);
         $reflectionMethod = $reflectionClass->getMethod('__clone');
         $this->assertTrue($reflectionMethod->isPrivate(), 'The method __clone must be private');
-        $this->assertTrue($reflectionMethod->isFinal(), 'The method __clone must be final');
 
         $reflectionMethod->setAccessible(true);
         $this->expectException(LogicException::class);

--- a/tests/MabeEnumTest/EnumTest.php
+++ b/tests/MabeEnumTest/EnumTest.php
@@ -245,7 +245,7 @@ class EnumTest extends TestCase
             $this->assertSame($expectedNames[$i], $names[$i]);
         }
     }
-    
+
     public function testGetOrdinals(): void
     {
         $constants = EnumInheritance::getConstants();
@@ -376,7 +376,8 @@ class EnumTest extends TestCase
 
         $reflectionClass  = new ReflectionClass($enum);
         $reflectionMethod = $reflectionClass->getMethod('__clone');
-        $this->assertTrue($reflectionMethod->isPrivate(), 'The method __clone must be private');
+        $this->assertTrue($reflectionMethod->isProtected(), 'The method __clone must be protected');
+        $this->assertTrue($reflectionMethod->isFinal(), 'The method __clone must be final');
 
         $reflectionMethod->setAccessible(true);
         $this->expectException(LogicException::class);
@@ -431,7 +432,7 @@ class EnumTest extends TestCase
             'PUB'  => ConstVisibilityEnum::PUB,
         ), $constants);
     }
-    
+
     public function testConstVisibilityExtended(): void
     {
         $constants = ConstVisibilityEnumExtended::getConstants();


### PR DESCRIPTION
In PHP8 it occurs this warning.
> Private methods cannot be final as they are never overridden by other classes

Caused by this PHP8 change https://wiki.php.net/rfc/inheritance_private_methods

`private` and `final` modifiers can't be used both.