### PR TITLE
PHP-8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ matrix:
       env:
         - CODE_COVERAGE="0"
         - BENCHMARK="0"
+        - IGNORE_PLATFORM_REQS="1"
   allow_failures:
     - php: nightly
 
@@ -49,7 +50,11 @@ install:
   - if [ "${BENCHMARK}" == "0" ]; then
       composer remove --dev phpbench/phpbench --no-update;
     fi
-  - composer install -n
+  - if [ "${IGNORE_PLATFORM_REQS}" == "1" ]; then
+      composer install -n --ignore-platform-reqs;
+    else
+      composer install -n;
+    fi
 
 script:
   - if [ "$CODE_COVERAGE" == "1" ]; then

--- a/bench/bootstrap.php
+++ b/bench/bootstrap.php
@@ -6,8 +6,5 @@ if ($zendassertions != -1) {
         . "Current ini setting: zend.assertions = {$zendassertions}]" . PHP_EOL;
     exit(1);
 }
-assert_options(ASSERT_ACTIVE, 0);
-assert_options(ASSERT_WARNING, 0);
-assert_options(ASSERT_BAIL, 0);
 
 require_once __DIR__ . '/../vendor/autoload.php';

--- a/bench/bootstrap.php
+++ b/bench/bootstrap.php
@@ -9,6 +9,5 @@ if ($zendassertions != -1) {
 assert_options(ASSERT_ACTIVE, 0);
 assert_options(ASSERT_WARNING, 0);
 assert_options(ASSERT_BAIL, 0);
-assert_options(ASSERT_QUIET_EVAL, 0);
 
 require_once __DIR__ . '/../vendor/autoload.php';

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     }],
     "license": "BSD-3-Clause",
     "require": {
-        "php":            ">=7.1",
+        "php":            "^7.1 | ^8.0",
         "ext-reflection": "*"
     },
     "require-dev": {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -11,18 +11,6 @@ if ($zendassertions == -1) {
     exit(1);
 }
 
-// activate assertions
-assert_options(ASSERT_ACTIVE, 1);
-assert_options(ASSERT_WARNING, 0);
-assert_options(ASSERT_BAIL, 0);
-if (!class_exists('AssertionError')) {
-    // AssertionError has been added in PHP-7.0
-    class AssertionError extends Exception {};
-}
-assert_options(ASSERT_CALLBACK, function($file, $line, $code) {
-    throw new AssertionError("assert(): Assertion '{$code}' failed in {$file} on line {$line}");
-});
-
 // installed itself
 if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
     require_once __DIR__ . '/../vendor/autoload.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -15,7 +15,6 @@ if ($zendassertions == -1) {
 assert_options(ASSERT_ACTIVE, 1);
 assert_options(ASSERT_WARNING, 0);
 assert_options(ASSERT_BAIL, 0);
-assert_options(ASSERT_QUIET_EVAL, 0);
 if (!class_exists('AssertionError')) {
     // AssertionError has been added in PHP-7.0
     class AssertionError extends Exception {};


### PR DESCRIPTION
* PHP-8 compatibility
* Restrict required PHP version to be ^7.1 or ^8.0 (before only the min version was defined)
* Removed assertion polyfill code in tests and bench bootstrap for php < 7.0
  * this also fixes a segmentation fault running tests on PHP 8.0-rc
