### PR TITLE
Remove final keyword from private methods

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -56,7 +56,7 @@ abstract class Enum
      * @param null|bool|int|float|string|array $value   The value of the enumerator
      * @param int|null                         $ordinal The ordinal number of the enumerator
      */
-    final private function __construct($value, $ordinal = null)
+    private function __construct($value, $ordinal = null)
     {
         $this->value   = $value;
         $this->ordinal = $ordinal;
@@ -77,7 +77,7 @@ abstract class Enum
      * @throws LogicException Enums are not cloneable
      *                        because instances are implemented as singletons
      */
-    final private function __clone()
+    private function __clone()
     {
         throw new LogicException('Enums are not cloneable');
     }

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -56,7 +56,7 @@ abstract class Enum
      * @param null|bool|int|float|string|array $value   The value of the enumerator
      * @param int|null                         $ordinal The ordinal number of the enumerator
      */
-    private function __construct($value, $ordinal = null)
+    final private function __construct($value, $ordinal = null)
     {
         $this->value   = $value;
         $this->ordinal = $ordinal;


### PR DESCRIPTION
This throws PHP Warning: Private methods cannot be final as they are never overridden by other classes in PHP 8.0