### PR TITLE
Remove final keyword from private constructor

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -60,7 +60,7 @@ abstract class Enum
      * @param null|bool|int|float|string|array<mixed> $value   The value of the enumerator
      * @param int|null                                $ordinal The ordinal number of the enumerator
      */
-    final private function __construct($value, $ordinal = null)
+    private function __construct($value, $ordinal = null)
     {
         $this->value   = $value;
         $this->ordinal = $ordinal;


### PR DESCRIPTION
This throws PHP Warning: Private methods cannot be final as they are never overridden by other classes in PHP 8.0

Same as #151, but for master instead of `3.x`