### PR TITLE
Implement Stringable interface on Enum

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,17 +29,17 @@
     "autoload": {
         "psr-4": {
             "MabeEnum\\": "src/"
-        }
+        },
+        "classmap": [
+            "stubs/Stringable.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {
             "MabeEnumTest\\":  "tests/MabeEnumTest/",
             "MabeEnumStaticAnalysis\\": "tests/MabeEnumStaticAnalysis/",
             "MabeEnumBench\\": "bench/"
-        },
-        "classmap": [
-            "stubs/Stringable.php"
-        ]
+        }
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,10 @@
             "MabeEnumTest\\":  "tests/MabeEnumTest/",
             "MabeEnumStaticAnalysis\\": "tests/MabeEnumStaticAnalysis/",
             "MabeEnumBench\\": "bench/"
-        }
+        },
+        "classmap": [
+            "stubs/Stringable.php"
+        ]
     },
     "extra": {
         "branch-alias": {

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0"?>
 <psalm
-    totallyTyped="true"
     errorLevel="1"
     resolveFromConfigFile="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -17,7 +17,7 @@ use LogicException;
  *
  * @psalm-immutable
  */
-abstract class Enum
+abstract class Enum implements \Stringable
 {
     /**
      * The selected enumerator value

--- a/stubs/Stringable.php
+++ b/stubs/Stringable.php
@@ -1,0 +1,11 @@
+<?php
+
+if (\PHP_VERSION_ID < 80000) {
+    interface Stringable
+    {
+        /**
+         * @return string
+         */
+        public function __toString();
+    }
+}


### PR DESCRIPTION
Enum class has a __toString, so it would be great to implements the new Stringable interface.

As the interface is not available for php < 8, I've had the symfony/polyfill-php-80.

I've removed psalm `totallyTyped` attribute as it's now deprecated.