### PR TITLE
Fixed bug with constant inheritance

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -386,7 +386,7 @@ abstract class Enum implements \Stringable
             $scopeConstants = [];
             // Enumerators must be defined as public class constants
             foreach ($reflection->getReflectionConstants() as $reflConstant) {
-                if ($reflConstant->isPublic()) {
+                if (!isset($constants[$reflConstant->getName()]) && $reflConstant->isPublic()) {
                     $scopeConstants[ $reflConstant->getName() ] = $reflConstant->getValue();
                 }
             }


### PR DESCRIPTION
If a constant already exists in the inherited class, then it cannot be redefined. Which leads to the error.